### PR TITLE
Add some Python nodes

### DIFF
--- a/arborista/nodes/python/compound_statement.py
+++ b/arborista/nodes/python/compound_statement.py
@@ -1,0 +1,6 @@
+"""A Python compound statement."""
+from arborista.nodes.python.statement import Statement
+
+
+class CompoundStatement(Statement):  # pylint: disable=too-few-public-methods
+    """A Python compound statement."""

--- a/arborista/nodes/python/function_definition.py
+++ b/arborista/nodes/python/function_definition.py
@@ -1,0 +1,12 @@
+"""A Python function defintion."""
+from arborista.nodes.python.name import Name
+from arborista.nodes.python.parameter import ParameterList, Parameters
+from arborista.nodes.python.statement import Statement, StatementList, Statements
+
+
+class FunctionDefinition(Statement):  # pylint: disable=too-few-public-methods
+    """A Python function defintion."""
+    def __init__(self, name: Name, parameters: Parameters, body: Statements):
+        self.name: Name = name
+        self.parameters: ParameterList = list(parameters)
+        self.body: StatementList = list(body)

--- a/arborista/nodes/python/module.py
+++ b/arborista/nodes/python/module.py
@@ -1,0 +1,12 @@
+"""A Python module."""
+from typing import List
+
+from arborista.node import Node
+from arborista.nodes.python.statement import Statement, Statements
+
+
+class Module(Node):  # pylint: disable=too-few-public-methods
+    """A Python module."""
+    def __init__(self, name: str, statements: Statements):
+        self.name: str = name
+        self.statements: List[Statement] = list(statements)

--- a/arborista/nodes/python/name.py
+++ b/arborista/nodes/python/name.py
@@ -1,0 +1,8 @@
+"""A Python name."""
+from arborista.nodes.python.statement import Statement
+
+
+class Name(Statement):  # pylint: disable=too-few-public-methods
+    """A Python name."""
+    def __init__(self, value: str):
+        self.value: str = value

--- a/arborista/nodes/python/parameter.py
+++ b/arborista/nodes/python/parameter.py
@@ -1,0 +1,12 @@
+"""A Python parameter."""
+from typing import Iterable, List
+
+from arborista.nodes.python.statement import Statement
+
+
+class Parameter(Statement):  # pylint: disable=too-few-public-methods
+    """A Python parameter."""
+
+
+Parameters = Iterable[Parameter]
+ParameterList = List[Parameter]

--- a/arborista/nodes/python/return_statement.py
+++ b/arborista/nodes/python/return_statement.py
@@ -1,0 +1,6 @@
+"""A Python return statement."""
+from arborista.nodes.python.simple_statement import SimpleStatement
+
+
+class ReturnStatement(SimpleStatement):  # pylint: disable=too-few-public-methods
+    """A Python return statement."""

--- a/arborista/nodes/python/simple_statement.py
+++ b/arborista/nodes/python/simple_statement.py
@@ -1,0 +1,9 @@
+"""A Python simple statement."""
+from arborista.nodes.python.small_statement import SmallStatements
+from arborista.nodes.python.statement import Statement
+
+
+class SimpleStatement(Statement):  # pylint: disable=too-few-public-methods
+    """A Python simple statement."""
+    def __init__(self, small_statements: SmallStatements):
+        self.small_statements: SmallStatements = small_statements

--- a/arborista/nodes/python/small_statement.py
+++ b/arborista/nodes/python/small_statement.py
@@ -1,0 +1,11 @@
+"""A Python small statement."""
+from typing import Iterator
+
+from arborista.nodes.python.statement import Statement
+
+
+class SmallStatement(Statement):  # pylint: disable=too-few-public-methods
+    """A Python small statement."""
+
+
+SmallStatements = Iterator[SmallStatement]

--- a/arborista/nodes/python/statement.py
+++ b/arborista/nodes/python/statement.py
@@ -1,0 +1,12 @@
+"""A Python statement."""
+from typing import Iterable, List
+
+from arborista.node import Node
+
+
+class Statement(Node):  # pylint: disable=too-few-public-methods
+    """A Python statement."""
+
+
+Statements = Iterable[Statement]
+StatementList = List[Statement]

--- a/tests/nodes/python/test_compound_statement.py
+++ b/tests/nodes/python/test_compound_statement.py
@@ -1,0 +1,3 @@
+"""Test arborista.nodes.python.compound_statement."""
+# pylint: disable=unused-import
+from arborista.nodes.python.compound_statement import CompoundStatement

--- a/tests/nodes/python/test_function_definition.py
+++ b/tests/nodes/python/test_function_definition.py
@@ -1,0 +1,26 @@
+"""Test arborista.nodes.python.function_definition."""
+import pytest
+
+from arborista.nodes.python.function_definition import FunctionDefinition
+from arborista.nodes.python.name import Name
+from arborista.nodes.python.parameter import ParameterList, Parameters
+from arborista.nodes.python.statement import StatementList, Statements
+
+
+# yapf: disable
+@pytest.mark.parametrize('name, parameters, body, expected_parameters, expected_body', [
+    (Name('f'), [], [], [], []),
+    (Name('f'), [], iter([]), [], []),
+    (Name('f'), iter([]), [], [], []),
+    (Name('f'), iter([]), iter([]), [], []),
+])
+# yapf: enable
+def test_function_definition_init(name: Name, parameters: Parameters, body: Statements,
+                                  expected_parameters: ParameterList,
+                                  expected_body: StatementList) -> None:
+    """Test arborista.nodes.python.function_definition.__init__."""
+    function_definition: FunctionDefinition = FunctionDefinition(name, parameters, body)
+
+    assert function_definition.name == name
+    assert function_definition.parameters == expected_parameters
+    assert function_definition.body == expected_body

--- a/tests/nodes/python/test_module.py
+++ b/tests/nodes/python/test_module.py
@@ -1,0 +1,18 @@
+"""Test arborista.nodes.python.module."""
+import pytest
+
+from arborista.nodes.python.module import Module
+from arborista.nodes.python.statement import Statements
+
+
+# yapf: disable
+@pytest.mark.parametrize('name, statements', [
+    ('foo', [])
+])
+# yapf: enable
+def test_module_init(name: str, statements: Statements) -> None:
+    """Test arborista.nodes.python.module.__init__."""
+    module: Module = Module(name, statements)
+
+    assert module.name == name
+    assert module.statements == statements

--- a/tests/nodes/python/test_name.py
+++ b/tests/nodes/python/test_name.py
@@ -1,0 +1,16 @@
+"""Test arborista.nodes.python.name."""
+import pytest
+
+from arborista.nodes.python.name import Name
+
+
+# yapf: disable
+@pytest.mark.parametrize('value', [
+    ('f'),
+])
+# yapf: enable
+def test_init(value: str) -> None:
+    """Test arborista.nodes.python.name.__init__."""
+    name: Name = Name(value)
+
+    assert name.value == value

--- a/tests/nodes/python/test_parameter.py
+++ b/tests/nodes/python/test_parameter.py
@@ -1,0 +1,2 @@
+"""Test arborista.nodes.python.parameter."""
+from arborista.nodes.python.parameter import Parameter  # pylint: disable=unused-import

--- a/tests/nodes/python/test_return_statement.py
+++ b/tests/nodes/python/test_return_statement.py
@@ -1,0 +1,2 @@
+"""Test arborista.nodes.python.return_statement."""
+from arborista.nodes.python.return_statement import ReturnStatement  # pylint: disable=unused-import

--- a/tests/nodes/python/test_simple_statement.py
+++ b/tests/nodes/python/test_simple_statement.py
@@ -1,0 +1,17 @@
+"""Test arborista.nodes.python.simple_statement."""
+import pytest
+
+from arborista.nodes.python.simple_statement import SimpleStatement
+from arborista.nodes.python.small_statement import SmallStatements
+
+
+# yapf: disable
+@pytest.mark.parametrize('small_statements', [
+    ([]),
+])
+# yapf: enable
+def test_simple_statement_init(small_statements: SmallStatements) -> None:
+    """Test arborista.nodes.python.simple_statement.__init__."""
+    simple_statement: SimpleStatement = SimpleStatement(small_statements)
+
+    assert simple_statement.small_statements == small_statements

--- a/tests/nodes/python/test_small_statement.py
+++ b/tests/nodes/python/test_small_statement.py
@@ -1,0 +1,2 @@
+"""Test arborista.nodes.python.small_statement."""
+from arborista.nodes.python.small_statement import SmallStatement  # pylint: disable=unused-import

--- a/tests/nodes/python/test_statement.py
+++ b/tests/nodes/python/test_statement.py
@@ -1,0 +1,2 @@
+"""Test arborista.nodes.python.statement."""
+from arborista.nodes.python.statement import Statement  # pylint: disable=unused-import


### PR DESCRIPTION
Add definitions for the nodes needed to implement a transformation
which trims statements after a return statement in a function
definition.

For example, turn this function definition:
```Python3
def f():
    return
    return
```
into this function definition:
```Python3
def f():
    return
```

These nodes do not contain any CST information yet. They also do not
have parsing and printing methods.

One thing that I am finding difficult is reconciling the differences
between the [full grammer specification for Python 3.6](
https://docs.python.org/3.6/reference/grammar.html) and the [abstract
grammer](https://docs.python.org/3/library/ast.html) defined in the ast
library. Which of these should I be following? Probably the full grammer
spec?