### PR TITLE
Make Python module statements optional

### DIFF
--- a/arborista/nodes/python/module.py
+++ b/arborista/nodes/python/module.py
@@ -1,12 +1,17 @@
 """A Python module."""
-from typing import List
+from typing import Optional
 
 from arborista.node import Node
-from arborista.nodes.python.statement import Statement, Statements
+from arborista.nodes.python.statement import StatementList, Statements
 
 
 class Module(Node):  # pylint: disable=too-few-public-methods
     """A Python module."""
-    def __init__(self, name: str, statements: Statements):
+    def __init__(self, name: str, statements: Optional[Statements] = None):
         self.name: str = name
-        self.statements: List[Statement] = list(statements)
+
+        self.statements: StatementList
+        if statements is None:
+            self.statements = []
+        else:
+            self.statements = list(statements)

--- a/tests/nodes/python/test_module.py
+++ b/tests/nodes/python/test_module.py
@@ -1,18 +1,27 @@
 """Test arborista.nodes.python.module."""
+from typing import Optional
+
 import pytest
 
 from arborista.nodes.python.module import Module
-from arborista.nodes.python.statement import Statements
+from arborista.nodes.python.statement import StatementList, Statements
 
 
 # yapf: disable
-@pytest.mark.parametrize('name, statements', [
-    ('foo', [])
+@pytest.mark.parametrize('name, statements, pass_statements, expected_statements', [
+    ('foo', [], True, []),
+    ('foo', iter([]), True, []),
+    ('foo', None, False, []),
 ])
 # yapf: enable
-def test_module_init(name: str, statements: Statements) -> None:
+def test_module_init(name: str, statements: Optional[Statements], pass_statements: bool,
+                     expected_statements: StatementList) -> None:
     """Test arborista.nodes.python.module.__init__."""
-    module: Module = Module(name, statements)
+    module: Module
+    if pass_statements:
+        module = Module(name, statements)
+    else:
+        module = Module(name)
 
     assert module.name == name
-    assert module.statements == statements
+    assert module.statements == expected_statements


### PR DESCRIPTION
Make the passing of statements when initializing a Python module
optional. The default is to have an empty statement list.