### PR TITLE
Parallelize linting

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,4 +8,4 @@ ARBORISTA="$(realpath "${HERE}/..")"
 pushd "${ARBORISTA}" > /dev/null
 trap "popd > /dev/null" EXIT
 
-python3 -m pylint arborista tests
+python3 -m pylint -j 0 arborista tests


### PR DESCRIPTION
Add the `-j` flag to pylint with `0` as the argument to parallelize it
with the number of processors available on the machine.