### PR TITLE
Add indent to Python block

### DIFF
--- a/arborista/nodes/python/block.py
+++ b/arborista/nodes/python/block.py
@@ -7,8 +7,9 @@ from arborista.nodes.python.statement import StatementList, Statements
 
 class Block(PythonNode):  # pylint: disable=too-few-public-methods
     """A Python block."""
-    def __init__(self, body: Statements):
+    def __init__(self, body: Statements, indent: str):
         self.body: StatementList = list(body)
+        self.indent: str = indent
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Block):

--- a/arborista/parsers/python/block_parser.py
+++ b/arborista/parsers/python/block_parser.py
@@ -1,4 +1,6 @@
 """Parser for a Python block."""
+from typing import Optional
+
 import libcst
 
 from arborista.nodes.python.block import Block
@@ -21,5 +23,12 @@ class BlockParser(Parser):  # pylint: disable=too-few-public-methods
         body: StatementIterator = (StatementParser.parse_statement(libcst_statement)
                                    for libcst_statement in libcst_body)
 
-        block: Block = Block(body)
+        indent: str
+        libcst_indent: Optional[str] = libcst_block.indent
+        if libcst_indent is None:
+            indent = '    '
+        else:
+            indent = libcst_indent
+
+        block: Block = Block(body, indent)
         return block

--- a/tests/nodes/python/test_block.py
+++ b/tests/nodes/python/test_block.py
@@ -16,25 +16,30 @@ def test_inheritance() -> None:
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('body, expected_body', [
-    ([ReturnStatement()], [ReturnStatement()]),
-    ([ReturnStatement(), ReturnStatement(), ReturnStatement()], [ReturnStatement(), ReturnStatement(), ReturnStatement()]),
-    (iter([]), []),
-    (iter([ReturnStatement(), ReturnStatement(), ReturnStatement()]), [ReturnStatement(), ReturnStatement(), ReturnStatement()]),
+@pytest.mark.parametrize('body, expected_body, indent', [
+    ([ReturnStatement()], [ReturnStatement()], '    '),
+    ([ReturnStatement()], [ReturnStatement()], '\t'),
+    ([ReturnStatement(), ReturnStatement(), ReturnStatement()], [ReturnStatement(), ReturnStatement(), ReturnStatement()], '    '),
+    ([ReturnStatement(), ReturnStatement(), ReturnStatement()], [ReturnStatement(), ReturnStatement(), ReturnStatement()], '\t'),
+    (iter([]), [], '   '),
+    (iter([]), [], '\t'),
+    (iter([ReturnStatement(), ReturnStatement(), ReturnStatement()]), [ReturnStatement(), ReturnStatement(), ReturnStatement()], '    '),
+    (iter([ReturnStatement(), ReturnStatement(), ReturnStatement()]), [ReturnStatement(), ReturnStatement(), ReturnStatement()], '\t'),
 ])
 # yapf: enable # pylint: enable=line-too-long
-def test_init(body: Statements, expected_body: StatementList) -> None:
+def test_init(body: Statements, expected_body: StatementList, indent: str) -> None:
     """Test arborista.nodes.python.block.Block.__init__."""
-    block: Block = Block(body)
+    block: Block = Block(body, indent)
 
     assert block.body == expected_body
+    assert block.indent == indent
 
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('block, other, expected_equality', [
-    (Block([SimpleStatement([ReturnStatement()])]), 'foo', False),
-    (Block([SimpleStatement([ReturnStatement()])]), Block([SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])]), False),
-    (Block([SimpleStatement([ReturnStatement()])]), Block([SimpleStatement([ReturnStatement()])]), True),
+    (Block([SimpleStatement([ReturnStatement()])], '   '), 'foo', False),
+    (Block([SimpleStatement([ReturnStatement()])], '   '), Block([SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])], '   '), False),
+    (Block([SimpleStatement([ReturnStatement()])], '   '), Block([SimpleStatement([ReturnStatement()])], '   '), True),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_eq(block: Block, other: Any, expected_equality: bool) -> None:

--- a/tests/nodes/python/test_function_definition.py
+++ b/tests/nodes/python/test_function_definition.py
@@ -21,9 +21,9 @@ def test_inheritance() -> None:
 # yapf: disable
 @pytest.mark.parametrize('name, parameters, body, expected_parameters', [
     (Name('f'), [], ReturnStatement(), []),
-    (Name('f'), [], Block([SimpleStatement([ReturnStatement()])]), []),
+    (Name('f'), [], Block([SimpleStatement([ReturnStatement()])], '    '), []),
     (Name('f'), iter([]), ReturnStatement(), []),
-    (Name('f'), iter([]), Block([SimpleStatement([ReturnStatement()])]), []),
+    (Name('f'), iter([]), Block([SimpleStatement([ReturnStatement()])], '    '), []),
 ])
 # yapf: enable
 def test_function_definition_init(name: Name, parameters: Parameters, body: Suite,

--- a/tests/parsers/python/test_block_parser.py
+++ b/tests/parsers/python/test_block_parser.py
@@ -16,7 +16,7 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('libcst_block, expected_block', [
-    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])]), Block([SimpleStatement(small_statements=[ReturnStatement()])])),
+    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])]), Block([SimpleStatement(small_statements=[ReturnStatement()])], '   ')),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_block(libcst_block: LibcstBlock, expected_block: Block) -> None:

--- a/tests/parsers/python/test_compound_statement_parser.py
+++ b/tests/parsers/python/test_compound_statement_parser.py
@@ -20,7 +20,7 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('libcst_compound_statement, expected_compound_statement', [
-    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters(), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[], body=Block([SimpleStatement([ReturnStatement()])]))),
+    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters(), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[], body=Block([SimpleStatement([ReturnStatement()])], '    '))),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_compound_statement(libcst_compound_statement: LibcstCompoundStatement,

--- a/tests/parsers/python/test_function_definition_parser.py
+++ b/tests/parsers/python/test_function_definition_parser.py
@@ -20,8 +20,8 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('libcst_function_definition, expected_function_definition', [
-    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters(), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[], body=Block([SimpleStatement([ReturnStatement()])]))),
-    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters([libcst.Param(libcst.Name('bar'))]), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[Parameter(Name('bar'))], body=Block([SimpleStatement([ReturnStatement()])]))),
+    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters(), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[], body=Block([SimpleStatement([ReturnStatement()])], '   '))),
+    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters([libcst.Param(libcst.Name('bar'))]), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[Parameter(Name('bar'))], body=Block([SimpleStatement([ReturnStatement()])], '   '))),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_function_definition(libcst_function_definition: LibcstFunctionDefinition,

--- a/tests/parsers/python/test_suite_parser.py
+++ b/tests/parsers/python/test_suite_parser.py
@@ -18,7 +18,7 @@ def test_inheritance() -> None:
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('libcst_suite, expected_suite', [
     (libcst.SimpleStatementSuite([]), SimpleStatement([])),
-    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])]), Block([SimpleStatement(small_statements=[ReturnStatement()])])),
+    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])]), Block([SimpleStatement(small_statements=[ReturnStatement()])], '    ')),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_suite(libcst_suite: LibcstSuite, expected_suite: Suite) -> None:


### PR DESCRIPTION
Blocks are indented by a string. Unfortunately the off-sidedness of
Python (the syntactic significance of indentation) means that conversion
from a CST to a string will be context sensitive. It might make sense to
do all context sensitive processing inside of the lexer and maintain the
parser as context-free so that we can generate it with a parser
generator from EBNF or better yet named-ENBF (NEBNF?).