### PR TITLE
Enable useless linting supression detection

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
+[MESSAGE CONTROL]
+enable=useless-suppression
+
 [SIMILARITIES]
 ignore-imports=yes

--- a/arborista/nodes/python/block.py
+++ b/arborista/nodes/python/block.py
@@ -5,7 +5,7 @@ from arborista.nodes.python.python_node import PythonNode
 from arborista.nodes.python.statement import StatementList, Statements
 
 
-class Block(PythonNode):  # pylint: disable=too-few-public-methods
+class Block(PythonNode):
     """A Python block."""
     def __init__(self, body: Statements, indent: str):
         self.body: StatementList = list(body)

--- a/arborista/nodes/python/function_definition.py
+++ b/arborista/nodes/python/function_definition.py
@@ -7,7 +7,7 @@ from arborista.nodes.python.parameter import ParameterList, Parameters
 from arborista.nodes.python.suite import Suite
 
 
-class FunctionDefinition(CompoundStatement):  # pylint: disable=too-few-public-methods
+class FunctionDefinition(CompoundStatement):
     """A Python function defintion."""
     def __init__(self, name: Name, parameters: Parameters, body: Suite):
         self.name: Name = name

--- a/arborista/nodes/python/module.py
+++ b/arborista/nodes/python/module.py
@@ -5,7 +5,7 @@ from arborista.nodes.python.python_node import PythonNode
 from arborista.nodes.python.statement import StatementList, Statements
 
 
-class Module(PythonNode):  # pylint: disable=too-few-public-methods
+class Module(PythonNode):
     """A Python module."""
     def __init__(self, name: str, statements: Optional[Statements] = None):
         self.name: str = name

--- a/arborista/nodes/python/name.py
+++ b/arborista/nodes/python/name.py
@@ -4,7 +4,7 @@ from typing import Any
 from arborista.nodes.python.atom import Atom
 
 
-class Name(Atom):  # pylint: disable=too-few-public-methods
+class Name(Atom):
     """A Python name."""
     def __init__(self, value: str):
         self.value: str = value

--- a/arborista/nodes/python/parameter.py
+++ b/arborista/nodes/python/parameter.py
@@ -5,7 +5,7 @@ from arborista.nodes.python.name import Name
 from arborista.nodes.python.python_node import PythonNode
 
 
-class Parameter(PythonNode):  # pylint: disable=too-few-public-methods
+class Parameter(PythonNode):
     """A Python parameter."""
     def __init__(self, name: Name):
         self.name: Name = name

--- a/arborista/nodes/python/return_statement.py
+++ b/arborista/nodes/python/return_statement.py
@@ -4,7 +4,7 @@ from typing import Any
 from arborista.nodes.python.flow_statement import FlowStatement
 
 
-class ReturnStatement(FlowStatement):  # pylint: disable=too-few-public-methods
+class ReturnStatement(FlowStatement):
     """A Python return statement."""
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ReturnStatement):

--- a/arborista/nodes/python/simple_statement.py
+++ b/arborista/nodes/python/simple_statement.py
@@ -5,7 +5,7 @@ from arborista.nodes.python.small_statement import SmallStatementList, SmallStat
 from arborista.nodes.python.statement import Statement
 
 
-class SimpleStatement(Statement):  # pylint: disable=too-few-public-methods
+class SimpleStatement(Statement):
     """A Python simple statement."""
     def __init__(self, small_statements: SmallStatements):
         self.small_statements: SmallStatementList = list(small_statements)

--- a/tests/nodes/python/test_parameter.py
+++ b/tests/nodes/python/test_parameter.py
@@ -13,11 +13,11 @@ def test_inheritance() -> None:
     assert issubclass(Parameter, PythonNode)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('name', [
     (Name('foo')),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_init(name: Name) -> None:
     """Test arborista.nodes.python.parameter.Parameter.__init__."""
     parameter: Parameter = Parameter(name)

--- a/tests/nodes/python/test_small_statement.py
+++ b/tests/nodes/python/test_small_statement.py
@@ -1,6 +1,6 @@
 """Test arborista.nodes.python.small_statement."""
 from arborista.nodes.python.python_node import PythonNode
-from arborista.nodes.python.small_statement import SmallStatement  # pylint: disable=unused-import
+from arborista.nodes.python.small_statement import SmallStatement
 
 
 def test_inheritance() -> None:

--- a/tests/nodes/python/test_statement.py
+++ b/tests/nodes/python/test_statement.py
@@ -1,6 +1,6 @@
 """Test arborista.nodes.python.statement."""
 from arborista.nodes.python.python_node import PythonNode
-from arborista.nodes.python.statement import Statement  # pylint: disable=unused-import
+from arborista.nodes.python.statement import Statement
 
 
 def test_inheritance() -> None:

--- a/tests/parsers/file_system/test_file_parser.py
+++ b/tests/parsers/file_system/test_file_parser.py
@@ -18,7 +18,7 @@ def test_inheritance() -> None:
     (Path('foo'), 'bar', 'bar'),
 ])
 # yapf: enable
-def test_parse(file_path: Path, file_contents: str, expected_contents: str) -> None:  # pylint: disable=unused-argument
+def test_parse(file_path: Path, file_contents: str, expected_contents: str) -> None:
     """Test arborista.parsers.file_system.file_parser.FileParser.parse_file."""
     with patch('builtins.open', mock_open(read_data=file_contents)):
         contents: str = FileParser.parse_file(file_path)

--- a/tests/parsers/python/test_compound_statement_parser.py
+++ b/tests/parsers/python/test_compound_statement_parser.py
@@ -14,7 +14,7 @@ from arborista.parsers.python.compound_statement_parser import (CompoundStatemen
 
 
 def test_inheritance() -> None:
-    """Test arborista.parsers.python.compound_statement_parser.CompoundStatementParser inheritance."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.compound_statement_parser.CompoundStatementParser inheritance."""  # pylint: disable=line-too-long, useless-suppression
     assert issubclass(CompoundStatementParser, Parser)
 
 
@@ -25,7 +25,7 @@ def test_inheritance() -> None:
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_compound_statement(libcst_compound_statement: LibcstCompoundStatement,
                                   expected_compound_statement: CompoundStatement) -> None:
-    """Test arborista.parsers.python.compound_statement_parser.CompoundStatementParser.parse_compound_statement."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.compound_statement_parser.CompoundStatementParser.parse_compound_statement."""  # pylint: disable=line-too-long, useless-suppression
     compound_statement: CompoundStatement = CompoundStatementParser.parse_compound_statement(
         libcst_compound_statement)
     assert compound_statement == expected_compound_statement

--- a/tests/parsers/python/test_flow_statement_parser.py
+++ b/tests/parsers/python/test_flow_statement_parser.py
@@ -13,13 +13,13 @@ def test_inheritance() -> None:
     assert issubclass(FlowStatementParser, Parser)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('libcst_flow_statement, expected_flow_statement', [
     (libcst.Return(), ReturnStatement()),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_parse_flow_statement(libcst_flow_statement: LibcstFlowStatement,
                               expected_flow_statement: FlowStatement) -> None:
-    """Test arborista.parsers.python.flow_statement_parser.FlowStatementParser.parse_flow_statement."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.flow_statement_parser.FlowStatementParser.parse_flow_statement."""  # pylint: disable=line-too-long, useless-suppression
     flow_statement: FlowStatement = FlowStatementParser.parse_flow_statement(libcst_flow_statement)
     assert flow_statement == expected_flow_statement

--- a/tests/parsers/python/test_function_definition_parser.py
+++ b/tests/parsers/python/test_function_definition_parser.py
@@ -14,7 +14,7 @@ from arborista.parsers.python.function_definition_parser import (FunctionDefinit
 
 
 def test_inheritance() -> None:
-    """Test arborista.parsers.python.function_definition_parser.FunctionDefinitionParser inheritance."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.function_definition_parser.FunctionDefinitionParser inheritance."""  # pylint: disable=line-too-long, useless-suppression
     assert issubclass(FunctionDefinitionParser, Parser)
 
 
@@ -26,7 +26,7 @@ def test_inheritance() -> None:
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_function_definition(libcst_function_definition: LibcstFunctionDefinition,
                                    expected_function_definition: FunctionDefinition) -> None:
-    """Test arborista.parsers.python.function_definition_parser.FunctionDefinitionParser.parse_function_definition."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.function_definition_parser.FunctionDefinitionParser.parse_function_definition."""  # pylint: disable=line-too-long, useless-suppression
     function_definition = FunctionDefinitionParser.parse_function_definition(
         libcst_function_definition)
     assert function_definition == expected_function_definition

--- a/tests/parsers/python/test_name_parser.py
+++ b/tests/parsers/python/test_name_parser.py
@@ -12,11 +12,11 @@ def test_inheritance() -> None:
     assert issubclass(NameParser, Parser)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('libcst_name, expected_name', [
     (libcst.Name('foo'), Name('foo')),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_parse_name(libcst_name: LibcstName, expected_name: Name) -> None:
     """Test arborista.parsers.python.name_parser.NameParser.parse_name."""
     name: Name = NameParser.parse_name(libcst_name)

--- a/tests/parsers/python/test_parameter_parser.py
+++ b/tests/parsers/python/test_parameter_parser.py
@@ -14,11 +14,11 @@ def test_inheritance() -> None:
     assert issubclass(ParameterParser, Parser)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('libcst_parameter, expected_parameter', [
     (libcst.Param(libcst.Name('foo')), Parameter(Name('foo'))),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_parse_parameter(libcst_parameter: LibcstParameter, expected_parameter: Parameter) -> None:
     """Test arborista.parsers.python.parameter_parser.ParameterParser.parse_parameter."""
     parameter: Parameter = ParameterParser.parse_parameter(libcst_parameter)

--- a/tests/parsers/python/test_return_statement_parser.py
+++ b/tests/parsers/python/test_return_statement_parser.py
@@ -13,14 +13,14 @@ def test_inheritance() -> None:
     assert issubclass(ReturnStatementParser, Parser)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('libcst_return_statement, expected_return_statement', [
     (libcst.Return(), ReturnStatement()),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_parse_return_statement(libcst_return_statement: LibcstReturnStatement,
                                 expected_return_statement: ReturnStatement) -> None:
-    """Test arborista.parsers.python.return_statement_parser.ReturnStatementParser.parse_return_statement."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.return_statement_parser.ReturnStatementParser.parse_return_statement."""  # pylint: disable=line-too-long, useless-suppression
     return_statement: ReturnStatement = ReturnStatementParser.parse_return_statement(
         libcst_return_statement)
     assert return_statement == expected_return_statement

--- a/tests/parsers/python/test_simple_statement_parser.py
+++ b/tests/parsers/python/test_simple_statement_parser.py
@@ -21,7 +21,7 @@ def test_inheritance() -> None:
 # yapf: enable
 def test_parse_simple_statement(libcst_simple_statement: LibcstSimpleStatement,
                                 expected_simple_statement: SimpleStatement) -> None:
-    """Test arborista.parsers.python.simple_statement_parser.SimpleStatementParser.parse_simple_statement."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.simple_statement_parser.SimpleStatementParser.parse_simple_statement."""  # pylint: disable=line-too-long, useless-suppression
     simple_statement: SimpleStatement = SimpleStatementParser.parse_simple_statement(
         libcst_simple_statement)
     assert simple_statement == expected_simple_statement

--- a/tests/parsers/python/test_small_statement_parser.py
+++ b/tests/parsers/python/test_small_statement_parser.py
@@ -15,27 +15,27 @@ def test_inheritance() -> None:
     assert issubclass(SmallStatementParser, Parser)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('libcst_small_statement, expected_small_statement', [
     (libcst.Return(), ReturnStatement()),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_parse_small_statement(libcst_small_statement: LibcstSmallStatement,
                                expected_small_statement: SmallStatement) -> None:
-    """Test arborista.parsers.python.small_statement_parser.SmallStatementParser.parse_small_statement."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.small_statement_parser.SmallStatementParser.parse_small_statement."""  # pylint: disable=line-too-long, useless-suppression
     small_statement: SmallStatement = SmallStatementParser.parse_small_statement(
         libcst_small_statement)
     assert small_statement == expected_small_statement
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('libcst_small_statements, expected_small_statements', [
     ([libcst.Return()], [ReturnStatement()]),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_parse_small_statements(libcst_small_statements: LibcstSmallStatements,
                                 expected_small_statements: SmallStatementList) -> None:
-    """Test arborista.parsers.python.small_statement_parser.SmallStatementParser.parse_small_statements."""  # pylint: disable=line-too-long
+    """Test arborista.parsers.python.small_statement_parser.SmallStatementParser.parse_small_statements."""  # pylint: disable=line-too-long, useless-suppression
     small_statements: SmallStatementList = SmallStatementParser.parse_small_statements(
         libcst_small_statements)
     assert small_statements == expected_small_statements

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,11 +103,11 @@ def test_run_transformer() -> None:
         run_mock.assert_called_once()
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('argument_parser, parsed_arguments, arguments', [
     (argument_parser_from_dict({}), argparse.Namespace(), []),
 ])
-# yapf: enable # pylint: disable=enable-too-long
+# yapf: enable
 def test_main(argument_parser: argparse.ArgumentParser, parsed_arguments: argparse.Namespace,
               arguments: List[str]) -> None:
     """Test arborista.main.main."""


### PR DESCRIPTION
Enable pylint to warn about useless supression of warnings and errors.