### PR TITLE
Ascola/add file argument

### DIFF
--- a/arborista/main.py
+++ b/arborista/main.py
@@ -1,9 +1,15 @@
 """Main module."""
 import argparse
 import logging
-from typing import List
+from pathlib import Path
+from typing import List, cast
 
-from arborista.node import Node
+from arborista.deparsers.file_system.file_deparser import FileDeparser
+from arborista.deparsers.python.module_deparser import ModuleDeparser
+from arborista.nodes.file_system.file import File
+from arborista.nodes.python.module import Module
+from arborista.parsers.file_system.file_parser import FileParser
+from arborista.parsers.python.module_parser import ModuleParser
 from arborista.transformation import Transformations
 from arborista.transformer import Transformer
 from arborista.tree import Tree
@@ -36,20 +42,27 @@ def _parse_arguments(argument_parser: argparse.ArgumentParser,
     return parsed_arguments
 
 
-def _run_transformer() -> None:
-    """Run the transformer with a set of transformations on the Python code."""
+def _run_arborista(parsed_arguments: argparse.Namespace) -> None:
+    """Run arborista."""
+    file_path: Path = Path(parsed_arguments.file)
+    file_: File = FileParser.parse_file(file_path)
+    module: Module = ModuleParser.parse_module_from_file(file_)
+    tree: Tree = Tree(module)
+
     transformations: Transformations = []
     transformer = Transformer(transformations)
-    root: Node = Node()
-    tree: Tree = Tree(root)
     transformer.run(tree)
+
+    module_after: Module = cast(Module, tree.root)
+    transformed_contents: str = ModuleDeparser.deparse_module(module_after)
+    file_.contents = transformed_contents
+    FileDeparser.deparse_file(file_)
 
 
 def main(arguments: List[str]) -> int:
     """Main function."""
     argument_parser = _set_up_argument_parser()
-    parsed_arguments: argparse.Namespace = _parse_arguments(  #pylint: disable=unused-variable
-        argument_parser, arguments)
+    parsed_arguments: argparse.Namespace = _parse_arguments(argument_parser, arguments)
     _set_up_logging()
-    _run_transformer()
+    _run_arborista(parsed_arguments)
     return 0

--- a/arborista/main.py
+++ b/arborista/main.py
@@ -23,6 +23,9 @@ def _set_up_argument_parser() -> argparse.ArgumentParser:
     """Set up a argument parser."""
     argument_parser = argparse.ArgumentParser(prog=f'python3 -m {__package__}',
                                               description='A tree transformation tool.')
+
+    argument_parser.add_argument('file', help='file to process')
+
     return argument_parser
 
 

--- a/arborista/nodes/file_system/file.py
+++ b/arborista/nodes/file_system/file.py
@@ -23,3 +23,8 @@ class File(Node):
             return False
 
         return True
+
+    @property
+    def stem(self) -> str:
+        """Return the stem of the file path."""
+        return self.path.stem

--- a/arborista/parsers/python/module_parser.py
+++ b/arborista/parsers/python/module_parser.py
@@ -1,13 +1,14 @@
 """Parser for a Python module."""
 import libcst
 
+from arborista.nodes.file_system.file import File
 from arborista.nodes.python.module import Module
 from arborista.nodes.python.statement import StatementList
 from arborista.parser import Parser
 from arborista.parsers.python.statement_parser import LibcstStatements, StatementParser
 
 
-class ModuleParser(Parser):  # pylint: disable=too-few-public-methods
+class ModuleParser(Parser):
     """Parser for a Python module."""
     @staticmethod
     def parse_module(name: str, string: str) -> 'Module':
@@ -17,4 +18,12 @@ class ModuleParser(Parser):  # pylint: disable=too-few-public-methods
         body: StatementList = StatementParser.parse_statements(libcst_module_body)
 
         module: Module = Module(name, body)
+        return module
+
+    @staticmethod
+    def parse_module_from_file(file_: File) -> Module:
+        """Return a module from a file."""
+        name: str = file_.stem
+        string: str = file_.contents
+        module: Module = ModuleParser.parse_module(name, string)
         return module

--- a/tests/nodes/file_system/test_file.py
+++ b/tests/nodes/file_system/test_file.py
@@ -42,3 +42,16 @@ def test_eq(file_: File, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.file_system.file.File.__eq__."""
     equality: bool = file_ == other
     assert equality == expected_equality
+
+
+# yapf: disable
+@pytest.mark.parametrize('file_, expected_stem', [
+    (File(Path('foo'), ''), 'foo'),
+    (File(Path('foo.py'), ''), 'foo'),
+    (File(Path('foo/bar'), ''), 'bar'),
+    (File(Path('foo/bar.py'), ''), 'bar'),
+])
+# yapf: enable
+def test_stem(file_: File, expected_stem: str) -> None:
+    """Test arborista.nodes.file_system.file.File.stem."""
+    assert file_.stem == expected_stem

--- a/tests/parsers/python/test_module_parser.py
+++ b/tests/parsers/python/test_module_parser.py
@@ -1,6 +1,9 @@
 """Test arborista.parsing.python.module_parser."""
+from pathlib import Path
+
 import pytest
 
+from arborista.nodes.file_system.file import File
 from arborista.nodes.python.function_definition import FunctionDefinition
 from arborista.nodes.python.module import Module
 from arborista.nodes.python.name import Name
@@ -25,4 +28,16 @@ def test_inheritance() -> None:
 def test_parse_module(string: str, name: str, expected_module: Module) -> None:
     """Test arborista.parsing.python.module_parser.ModuleParser.parse_module."""
     module = ModuleParser.parse_module(name, string)
+    assert module == expected_module
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('file_, expected_module', [
+    (File(Path('foo.py'), ''), Module('foo')),
+    (File(Path('foo.py'), 'def f(): return'), Module('foo', [FunctionDefinition(name=Name('f'), parameters=[], body=SimpleStatement([ReturnStatement()]))])),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_parse_module_from_file(file_: File, expected_module: Module) -> None:
+    """Test arborista.parsing.python.module_parser.ModuleParser.parse_module_from_file."""
+    module: Module = ModuleParser.parse_module_from_file(file_)
     assert module == expected_module

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,6 +49,7 @@ def _assert_argument_parser_is_set_up(argument_parser: argparse.ArgumentParser) 
     """Assert the argument parser description and prog match the expected values."""
     _assert_argument_parser_description(argument_parser)
     _assert_argument_parser_prog(argument_parser)
+    _assert_argument_parser_arguments(argument_parser)
 
 
 def _assert_argument_parser_description(argument_parser: argparse.ArgumentParser) -> None:
@@ -59,6 +60,38 @@ def _assert_argument_parser_description(argument_parser: argparse.ArgumentParser
 def _assert_argument_parser_prog(argument_parser: argparse.ArgumentParser) -> None:
     """Assert the argument parser prog matches the expected value."""
     assert argument_parser.prog == 'python3 -m arborista'
+
+
+def _assert_argument_parser_arguments(argument_parser: argparse.ArgumentParser) -> None:
+    """Assert the argument parser arguments match the expected arguments."""
+    arguments: List[argparse.Action] = argument_parser._get_positional_actions()  # pylint: disable=protected-access
+
+    _assert_arguemnt_parser_number_of_arguments(arguments)
+
+    file_argument: argparse.Action = arguments[0]
+
+    _assert_file_argument_is_set_up(file_argument)
+
+
+def _assert_arguemnt_parser_number_of_arguments(arguments: List[argparse.Action]) -> None:
+    """Assert that the argument parser has the expected number of arguments."""
+    assert len(arguments) == 1
+
+
+def _assert_file_argument_is_set_up(file_argument: argparse.Action) -> None:
+    """Assert that the file argument is set up."""
+    _assert_file_argument_dest(file_argument)
+    _assert_file_argument_help(file_argument)
+
+
+def _assert_file_argument_dest(file_argument: argparse.Action) -> None:
+    """Assert that the file argument has the expected destination."""
+    assert file_argument.dest == 'file'
+
+
+def _assert_file_argument_help(file_argument: argparse.Action) -> None:
+    """Assert that the file argument has the expected help."""
+    assert file_argument.help == 'file to process'
 
 
 def argument_parser_from_dict(dictionary: Dict[str, Any]) -> argparse.ArgumentParser:


### PR DESCRIPTION
Add a file argument to main.

Adjust main to parse the file argument into as string then parse the
string into a module. The module is then transformed. The transformed
module is deparsed which involves turning it into a file and then
writing the file.

These three steps should really be three suites of transformations which
should be performed in succession. Id est, the transformer should have
the ability to run different sets of transformations with different
policies. The parsing should be a set of transformations which are
applied once, then the transformations which improve the Python nodes
should but applied in a repeated fashion until there are no more
improvements to be made, and then lasty the deparsing transformations
should be performed once.

It might be worth it to distinguish between transformations which have
side effects and those that don't in order to do lazy evaluation.