### PR TITLE
Make tree root optional

### DIFF
--- a/arborista/tree.py
+++ b/arborista/tree.py
@@ -1,8 +1,10 @@
 """A tree structure."""
+from typing import Optional
+
 from arborista.node import Node
 
 
 class Tree():  # pylint: disable=too-few-public-methods
     """A tree structure."""
-    def __init__(self, root: Node):
-        self.root: Node = root
+    def __init__(self, root: Optional[Node] = None):
+        self.root: Optional[Node] = root

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,10 +1,26 @@
 """Test arborista.tree."""
+from typing import Any, Dict, Optional
+
+import pytest
+
 from arborista.node import Node
 from arborista.tree import Tree
+from tests.animal_nodes import Dog
 
 
-def test_init() -> None:
+# yapf: disable
+@pytest.mark.parametrize('root, pass_root, expected_root', [
+    (None, False, None),
+    (None, True, None),
+    (Dog(), True, Dog()),
+])
+# yapf: enable
+def test_init(root: Optional[Node], pass_root: bool, expected_root: Optional[Node]) -> None:
     """Test arborista.tree.Tree.__init__"""
-    root: Node = Node()
-    tree: Tree = Tree(root)
-    assert tree.root == root
+    keyword_arguments: Dict[str, Any] = {}
+    if pass_root:
+        keyword_arguments['root'] = root
+
+    tree: Tree = Tree(**keyword_arguments)
+
+    assert tree.root == expected_root


### PR DESCRIPTION
Make the root node of a tree optional. Id est, the root of a tree can be
non-existent.