### PR TITLE
Ascola/change trim after return reference frame

### DIFF
--- a/arborista/exceptions/cannot_find_child_exception.py
+++ b/arborista/exceptions/cannot_find_child_exception.py
@@ -1,0 +1,6 @@
+"""Raised when a child node cannot be found in a parent node."""
+from arborista.exception import ArboristaException
+
+
+class CannotFindChildException(ArboristaException):
+    """Raised when a child node cannot be found in a parent node."""

--- a/arborista/transformations/python/trim_after_return.py
+++ b/arborista/transformations/python/trim_after_return.py
@@ -1,6 +1,7 @@
 """Transformation for trimming small statements after a return statement in simple statement."""
 from typing import Optional, cast
 
+from arborista.exceptions.cannot_find_child_exception import CannotFindChildException
 from arborista.node import Node, NodeTypeSet
 from arborista.nodes.python.return_statement import ReturnStatement
 from arborista.nodes.python.simple_statement import SimpleStatement
@@ -10,18 +11,29 @@ from arborista.transformation import Transformation
 
 class TrimAfterReturn(Transformation):  # pylint: disable=too-few-public-methods
     """Transformation for trimming small statements after a return statement in simple statement."""
-    NODE_TYPES: NodeTypeSet = {SimpleStatement}
+    NODE_TYPES: NodeTypeSet = {ReturnStatement}
 
     @classmethod
     def maybe_transform(cls, node: Node) -> Optional[Node]:
         """Trim small statements after a return statement in simple statement."""
         node.assert_is_type(cls.NODE_TYPES)
+        return_statement: ReturnStatement = cast(ReturnStatement, node)
 
-        simple_statement: SimpleStatement = cast(SimpleStatement, node)
-        small_statements: SmallStatementList = simple_statement.small_statements
-        for small_statement_index, small_statement in enumerate(small_statements):
-            if isinstance(small_statement, ReturnStatement):
-                simple_statement.small_statements = small_statements[:small_statement_index + 1]
-                break
+        parent: Optional[Node] = node.parent
+        if isinstance(parent, SimpleStatement):
+            simple_statement: SimpleStatement = parent
+            small_statements: SmallStatementList = simple_statement.small_statements
+            return_statement_id = id(return_statement)
 
-        return simple_statement
+            small_statement_index: int
+            for small_statement_index, small_statement in enumerate(small_statements):
+                if id(small_statement) == return_statement_id:
+                    break
+            else:
+                raise CannotFindChildException()
+
+            small_statements = small_statements[:small_statement_index + 1]
+            simple_statement.small_statements = small_statements
+        else:
+            raise NotImplementedError
+        return return_statement

--- a/tests/exceptions/test_cannot_find_child_exception.py
+++ b/tests/exceptions/test_cannot_find_child_exception.py
@@ -1,0 +1,8 @@
+"""Test arborista.exceptions.cannot_find_child_exception."""
+from arborista.exception import ArboristaException
+from arborista.exceptions.cannot_find_child_exception import CannotFindChildException
+
+
+def test_inheritance() -> None:
+    """Test arborista.exceptions.cannot_find_child_exception.CannotFindChildException inheritance."""  # pylint: disable=line-too-long, useless-suppression
+    assert issubclass(CannotFindChildException, ArboristaException)

--- a/tests/transformations/python/test_trim_after_return.py
+++ b/tests/transformations/python/test_trim_after_return.py
@@ -4,18 +4,21 @@ from typing import Optional, Type
 import pytest
 
 from arborista.exception import ArboristaException
+from arborista.exceptions.cannot_find_child_exception import CannotFindChildException
 from arborista.exceptions.unexpected_node_type_exception import UnexpectedNodeTypeException
 from arborista.node import Node
-from arborista.nodes.python.block import Block
+from arborista.nodes.python.function_definition import FunctionDefinition
+from arborista.nodes.python.name import Name
 from arborista.nodes.python.return_statement import ReturnStatement
 from arborista.nodes.python.simple_statement import SimpleStatement
 from arborista.transformation import Transformation
 from arborista.transformations.python.trim_after_return import TrimAfterReturn
+from arborista.tree import Tree
 
 
 def test_node_types() -> None:
     """Test arborista.python.transformations.trim_after_return.TrimAfterReturn.NODE_TYPES."""
-    assert TrimAfterReturn.NODE_TYPES == {SimpleStatement}
+    assert TrimAfterReturn.NODE_TYPES == {ReturnStatement}
 
 
 def test_inheritance() -> None:
@@ -23,15 +26,76 @@ def test_inheritance() -> None:
     assert issubclass(TrimAfterReturn, Transformation)
 
 
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('node, expected_result, expected_exception', [
-    (SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()]), None),
-    (SimpleStatement([ReturnStatement(), ReturnStatement()]), SimpleStatement([ReturnStatement()]), None),
-    (SimpleStatement([ReturnStatement(), ReturnStatement(), ReturnStatement()]), SimpleStatement([ReturnStatement()]), None),
-    (Block([SimpleStatement([ReturnStatement()])], indent='    '), None, UnexpectedNodeTypeException),
+node_0: Node = FunctionDefinition(Name('foo'), [], SimpleStatement([]))
+tree_0: Tree = Tree(root=node_0)
+expected_result_0: Optional[Node] = None
+expected_tree_0: Tree = Tree(root=node_0)
+expected_exception_0: Optional[Type[ArboristaException]] = UnexpectedNodeTypeException
+
+node_1: ReturnStatement = ReturnStatement()
+tree_1: Tree = Tree(root=SimpleStatement([node_1]))
+node_1.parent = tree_1.root
+expected_result_1: Optional[Node] = ReturnStatement()
+expected_tree_1: Tree = Tree(root=SimpleStatement([ReturnStatement()]))
+expected_exception_1: Optional[Type[ArboristaException]] = None
+
+node_2: ReturnStatement = ReturnStatement()
+tree_2: Tree = Tree(root=SimpleStatement([node_2, ReturnStatement()]))
+node_2.parent = tree_2.root
+expected_result_2: Optional[Node] = ReturnStatement()
+expected_tree_2: Tree = Tree(root=SimpleStatement([ReturnStatement()]))
+expected_exception_2: Optional[Type[ArboristaException]] = None
+
+node_3: ReturnStatement = ReturnStatement()
+tree_3: Tree = Tree(root=SimpleStatement([ReturnStatement(), node_3]))
+node_3.parent = tree_3.root
+expected_result_3: Optional[Node] = ReturnStatement()
+expected_tree_3: Tree = Tree(root=SimpleStatement([ReturnStatement(), ReturnStatement()]))
+expected_exception_3: Optional[Type[ArboristaException]] = None
+
+node_4: ReturnStatement = ReturnStatement()
+tree_4: Tree = Tree(root=SimpleStatement([node_4, ReturnStatement(), ReturnStatement()]))
+node_4.parent = tree_4.root
+expected_result_4: Optional[Node] = ReturnStatement()
+expected_tree_4: Tree = Tree(root=SimpleStatement([ReturnStatement()]))
+expected_exception_4: Optional[Type[ArboristaException]] = None
+
+node_5: ReturnStatement = ReturnStatement()
+tree_5: Tree = Tree(root=SimpleStatement([ReturnStatement(), node_5, ReturnStatement()]))
+node_5.parent = tree_5.root
+expected_result_5: Optional[Node] = ReturnStatement()
+expected_tree_5: Tree = Tree(root=SimpleStatement([ReturnStatement(), ReturnStatement()]))
+expected_exception_5: Optional[Type[ArboristaException]] = None
+
+node_6: ReturnStatement = ReturnStatement()
+tree_6: Tree = Tree(root=SimpleStatement([ReturnStatement(), ReturnStatement(), node_6]))
+node_6.parent = tree_6.root
+expected_result_6: Optional[Node] = ReturnStatement()
+expected_tree_6: Tree = Tree(root=SimpleStatement(
+    [ReturnStatement(), ReturnStatement(), ReturnStatement()]))
+expected_exception_6: Optional[Type[ArboristaException]] = None
+
+node_7: ReturnStatement = ReturnStatement()
+tree_7: Tree = Tree(root=SimpleStatement([ReturnStatement()]))
+node_7.parent = tree_7.root
+expected_result_7: Optional[Node] = None
+expected_tree_7: Tree = Tree(root=SimpleStatement([ReturnStatement()]))
+expected_exception_7: Optional[Type[ArboristaException]] = CannotFindChildException
+
+
+# yapf: disable
+@pytest.mark.parametrize('tree, node, expected_result, expected_tree, expected_exception', [
+    (tree_1, node_1, expected_result_1, expected_tree_1, expected_exception_1),
+    (tree_2, node_2, expected_result_2, expected_tree_2, expected_exception_2),
+    (tree_3, node_3, expected_result_3, expected_tree_3, expected_exception_3),
+    (tree_4, node_4, expected_result_4, expected_tree_4, expected_exception_4),
+    (tree_5, node_5, expected_result_5, expected_tree_5, expected_exception_5),
+    (tree_6, node_6, expected_result_6, expected_tree_6, expected_exception_6),
+    (tree_7, node_7, expected_result_7, expected_tree_7, expected_exception_7),
 ])
-# yapf: enable # pylint: enable=line-too-long
-def test_maybe_transform(node: Node, expected_result: Optional[Node],
+# yapf: enable
+def test_maybe_transform(tree: Tree, node: Node, expected_result: Optional[Node],
+                         expected_tree: Tree,
                          expected_exception: Optional[Type[ArboristaException]]) -> None:
     """Test arborista.python.transformations.trim_after_return.TrimAfterReturn.maybe_transform."""
     if expected_exception:
@@ -39,4 +103,7 @@ def test_maybe_transform(node: Node, expected_result: Optional[Node],
             TrimAfterReturn.maybe_transform(node)
     else:
         result: Optional[Node] = TrimAfterReturn.maybe_transform(node)
+
         assert result == expected_result
+
+    assert tree == expected_tree


### PR DESCRIPTION
Change the reference frame for the trim after return transformation from
the parent node to the return statement. It is easier to describe the
transformation from the perspective of the return statement than from
the perspective of the parent statement and it is easier to propogate
the information up rather than searching down arbitrary levels.

This still only handles simple statements and only one level of nesting.

It should be generalized to climb multiple levels in the hierarchy and
also to be any flow interruption statement (e.g. break statements too).
In addtion other types of structures such as block statements should be
supported.

The plan right now is to only have one transformation run at a time, but
it makes sense to parallelize transformation running in which case
locking of nodes, deadlock detection, and intelligent deadlock handling
need to be added too.