### PR TITLE
Add node children iteration

### DIFF
--- a/arborista/nodes/python/block.py
+++ b/arborista/nodes/python/block.py
@@ -1,7 +1,7 @@
 """A Python block."""
 from typing import Any, Optional
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator
 from arborista.nodes.python.python_node import PythonNode
 from arborista.nodes.python.statement import StatementList, Statements
 
@@ -19,3 +19,6 @@ class Block(PythonNode):
             return False
 
         return self.body == other.body
+
+    def iterate_children(self) -> NodeIterator:
+        yield from self.body

--- a/arborista/nodes/python/function_definition.py
+++ b/arborista/nodes/python/function_definition.py
@@ -1,7 +1,7 @@
 """A Python function defintion."""
 from typing import Any, Optional
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator
 from arborista.nodes.python.compound_statement import CompoundStatement
 from arborista.nodes.python.name import Name
 from arborista.nodes.python.parameter import ParameterList, Parameters
@@ -35,3 +35,8 @@ class FunctionDefinition(CompoundStatement):
             return False
 
         return True
+
+    def iterate_children(self) -> NodeIterator:
+        yield self.name
+        yield from self.parameters
+        yield self.body

--- a/arborista/nodes/python/module.py
+++ b/arborista/nodes/python/module.py
@@ -1,7 +1,7 @@
 """A Python module."""
 from typing import Any, Optional
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator
 from arborista.nodes.python.python_node import PythonNode
 from arborista.nodes.python.statement import StatementList, Statements
 
@@ -33,3 +33,6 @@ class Module(PythonNode):
             return False
 
         return True
+
+    def iterate_children(self) -> NodeIterator:
+        yield from self.statements

--- a/arborista/nodes/python/parameter.py
+++ b/arborista/nodes/python/parameter.py
@@ -1,7 +1,7 @@
 """A Python parameter."""
 from typing import Any, Iterable, List, Optional
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator
 from arborista.nodes.python.name import Name
 from arborista.nodes.python.python_node import PythonNode
 
@@ -17,6 +17,9 @@ class Parameter(PythonNode):
         if not isinstance(other, Parameter):
             return False
         return self.name == other.name
+
+    def iterate_children(self) -> NodeIterator:
+        yield self.name
 
 
 Parameters = Iterable[Parameter]

--- a/arborista/nodes/python/simple_statement.py
+++ b/arborista/nodes/python/simple_statement.py
@@ -1,7 +1,7 @@
 """A Python simple statement."""
 from typing import Any, Optional
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator
 from arborista.nodes.python.small_statement import SmallStatementList, SmallStatements
 from arborista.nodes.python.statement import Statement
 
@@ -20,3 +20,6 @@ class SimpleStatement(Statement):
             return False
         return all(small_statement == other_small_statement for small_statement,
                    other_small_statement in zip(self.small_statements, other.small_statements))
+
+    def iterate_children(self) -> NodeIterator:
+        yield from self.small_statements

--- a/tests/nodes/python/test_block.py
+++ b/tests/nodes/python/test_block.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator, NodeList
 from arborista.nodes.python.block import Block
 from arborista.nodes.python.function_definition import FunctionDefinition
 from arborista.nodes.python.name import Name
@@ -71,3 +71,17 @@ def test_eq(block: Block, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.block.Block.__eq__."""
     equality: bool = block == other
     assert equality == expected_equality
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('block, expected_children_list', [
+    (Block([SimpleStatement([ReturnStatement()])], '   '), [SimpleStatement([ReturnStatement()])]),
+    (Block([SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])], '   '), [SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])]),
+    (Block([SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])], '   '), [SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])]),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_iterate_children(block: Block, expected_children_list: NodeList) -> None:
+    """Test arborista.nodes.python.block.Block.iterate_children."""
+    children: NodeIterator = block.iterate_children()
+    children_list: NodeList = list(children)
+    assert children_list == expected_children_list

--- a/tests/nodes/python/test_function_definition.py
+++ b/tests/nodes/python/test_function_definition.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator, NodeList
 from arborista.nodes.python.block import Block
 from arborista.nodes.python.compound_statement import CompoundStatement
 from arborista.nodes.python.function_definition import FunctionDefinition
@@ -67,3 +67,20 @@ def test_eq(function_definition: FunctionDefinition, other: Any, expected_equali
     """Test arborista.nodes.python.function_definition.__eq__."""
     equality: bool = function_definition == other
     assert equality == expected_equality
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('function_definition, expected_children_list', [
+    (FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), [Name('foo'), SimpleStatement([ReturnStatement()])]),
+    (FunctionDefinition(Name('foo'), [], Block([SimpleStatement([ReturnStatement()])], '    ')), [Name('foo'), Block([SimpleStatement([ReturnStatement()])], '    ')]),
+    (FunctionDefinition(Name('foo'), [Parameter(Name('x'))], SimpleStatement([ReturnStatement()])), [Name('foo'), Parameter(Name('x')), SimpleStatement([ReturnStatement()])]),
+    (FunctionDefinition(Name('foo'), [Parameter(Name('x'))], SimpleStatement([ReturnStatement()])), [Name('foo'), Parameter(Name('x')), SimpleStatement([ReturnStatement()])]),
+    (FunctionDefinition(Name('foo'), [Parameter(Name('x')), Parameter(Name('y')), Parameter(Name('z'))], SimpleStatement([ReturnStatement()])), [Name('foo'), Parameter(Name('x')), Parameter(Name('y')), Parameter(Name('z')), SimpleStatement([ReturnStatement()])]),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_iterate_children(function_definition: FunctionDefinition,
+                          expected_children_list: NodeList) -> None:
+    """Test arborista.nodes.python.function_definition.iterate_children."""
+    children: NodeIterator = function_definition.iterate_children()
+    children_list: NodeList = list(children)
+    assert children_list == expected_children_list

--- a/tests/nodes/python/test_module.py
+++ b/tests/nodes/python/test_module.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator, NodeList
 from arborista.nodes.python.function_definition import FunctionDefinition
 from arborista.nodes.python.module import Module
 from arborista.nodes.python.name import Name
@@ -62,3 +62,16 @@ def test_eq(module: Module, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.module.__eq__."""
     equality: bool = module == other
     assert equality == expected_equality
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('module, expected_children_list', [
+    (Module('foo'), []),
+    (Module('foo', [FunctionDefinition(Name('bar'), [], SimpleStatement([ReturnStatement()]))]), [FunctionDefinition(Name('bar'), [], SimpleStatement([ReturnStatement()]))]),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_iterate_children(module: Module, expected_children_list: NodeList) -> None:
+    """Test arborista.nodes.python.module.iterate_children."""
+    children: NodeIterator = module.iterate_children()
+    children_list: NodeList = list(children)
+    assert children_list == expected_children_list

--- a/tests/nodes/python/test_parameter.py
+++ b/tests/nodes/python/test_parameter.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator, NodeList
 from arborista.nodes.python.function_definition import FunctionDefinition
 from arborista.nodes.python.name import Name
 from arborista.nodes.python.parameter import Parameter
@@ -45,3 +45,15 @@ def test_eq(parameter: Parameter, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.parameter.Parameter.__eq__."""
     equality: bool = parameter == other
     assert equality == expected_equality
+
+
+# yapf: disable
+@pytest.mark.parametrize('parameter, expected_children_list', [
+    (Parameter(Name('foo')), [Name('foo')]),
+])
+# yapf: enable
+def test_iterate_children(parameter: Parameter, expected_children_list: NodeList) -> None:
+    """Test arborista.nodes.python.parameter.Parameter.iterate_children."""
+    children: NodeIterator = parameter.iterate_children()
+    children_list: NodeList = list(children)
+    assert children_list == expected_children_list

--- a/tests/nodes/python/test_simple_statement.py
+++ b/tests/nodes/python/test_simple_statement.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from arborista.node import Node
+from arborista.node import Node, NodeIterator, NodeList
 from arborista.nodes.python.block import Block
 from arborista.nodes.python.return_statement import ReturnStatement
 from arborista.nodes.python.simple_statement import SimpleStatement
@@ -46,3 +46,18 @@ def test_eq(simple_statement: SimpleStatement, other: Any, expected_equality: bo
     """Test arborista.nodes.python.simple_statement.__eq__."""
     equality: bool = simple_statement == other
     assert equality == expected_equality
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('simple_statement, expected_children_list', [
+    (SimpleStatement(small_statements=[]), []),
+    (SimpleStatement(small_statements=[ReturnStatement()]), [ReturnStatement()]),
+    (SimpleStatement(small_statements=[ReturnStatement(), ReturnStatement(), ReturnStatement()]), [ReturnStatement(), ReturnStatement(), ReturnStatement()]),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_iterate_children(simple_statement: SimpleStatement,
+                          expected_children_list: NodeList) -> None:
+    """Test arborista.nodes.python.simple_statement.iterate_children."""
+    children: NodeIterator = simple_statement.iterate_children()
+    children_list: NodeList = list(children)
+    assert children_list == expected_children_list


### PR DESCRIPTION
Add iteration of children nodes for different node types. The need for
child iteration comes from the transformer needing to be able to walk
the tree.

Some nodes probably need have their data converted into new node types
so that the data can be transformed. For example, the contents of the
file node should probably be converted into a node so that it can parsed
from a string into a module by a parsing transformation. All this is to
say that more work needs to be done for adding child iteration.