### PR TITLE
Change file contents to be a node

### DIFF
--- a/arborista/deparsers/file_system/file_deparser.py
+++ b/arborista/deparsers/file_system/file_deparser.py
@@ -1,6 +1,7 @@
 """Deparser for a file."""
 from arborista.deparser import Deparser
 from arborista.nodes.file_system.file import File
+from arborista.nodes.sequences.text.string import String
 
 
 class FileDeparser(Deparser):  # pylint: disable=too-few-public-methods
@@ -9,4 +10,7 @@ class FileDeparser(Deparser):  # pylint: disable=too-few-public-methods
     def deparse_file(file_: File) -> None:
         """Deparse a file."""
         with open(file_.path, 'w') as system_file:
-            system_file.write(file_.contents)
+            if isinstance(file_.contents, String):
+                system_file.write(file_.contents.value)
+            else:
+                raise NotImplementedError

--- a/arborista/main.py
+++ b/arborista/main.py
@@ -8,6 +8,7 @@ from arborista.deparsers.file_system.file_deparser import FileDeparser
 from arborista.deparsers.python.module_deparser import ModuleDeparser
 from arborista.nodes.file_system.file import File
 from arborista.nodes.python.module import Module
+from arborista.nodes.sequences.text.string import String
 from arborista.parsers.file_system.file_parser import FileParser
 from arborista.parsers.python.module_parser import ModuleParser
 from arborista.transformation import TransformationSet
@@ -56,7 +57,8 @@ def _run_arborista(parsed_arguments: argparse.Namespace) -> None:
 
     module_after: Module = cast(Module, tree.root)
     transformed_contents: str = ModuleDeparser.deparse_module(module_after)
-    file_.contents = transformed_contents
+    string: String = String(transformed_contents)
+    file_.contents = string
     FileDeparser.deparse_file(file_)
 
 

--- a/arborista/nodes/file_system/file.py
+++ b/arborista/nodes/file_system/file.py
@@ -8,11 +8,11 @@ from arborista.node import Node
 
 class File(Node):
     """A file system file."""
-    def __init__(self, path: Path, contents: str, parent: Optional[Node] = None):
+    def __init__(self, path: Path, contents: Node, parent: Optional[Node] = None):
         super().__init__(parent)
 
         self.path: Path = path
-        self.contents: str = contents
+        self.contents: Node = contents
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, File):

--- a/arborista/nodes/sequences/text/string.py
+++ b/arborista/nodes/sequences/text/string.py
@@ -6,7 +6,7 @@ from arborista.node import Node
 
 class String(Node):
     """A string of characters."""
-    def __init__(self, value: str='', parent: Optional[Node] = None):
+    def __init__(self, value: str = '', parent: Optional[Node] = None):
         super().__init__(parent)
 
         self.value: str = value

--- a/arborista/parsers/file_system/file_parser.py
+++ b/arborista/parsers/file_system/file_parser.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from arborista.nodes.file_system.file import File
 from arborista.parser import Parser
+from arborista.nodes.sequences.text.string import String
 
 
 class FileParser(Parser):  # pylint: disable=too-few-public-methods
@@ -12,5 +13,9 @@ class FileParser(Parser):  # pylint: disable=too-few-public-methods
         """Parse a file."""
         with open(file_path) as system_file:
             contents: str = system_file.read()
-        file_: File = File(file_path, contents)
+
+        string: String = String(contents)
+
+        file_: File = File(file_path, string)
+
         return file_

--- a/arborista/parsers/python/module_parser.py
+++ b/arborista/parsers/python/module_parser.py
@@ -4,6 +4,7 @@ import libcst
 from arborista.nodes.file_system.file import File
 from arborista.nodes.python.module import Module
 from arborista.nodes.python.statement import StatementList
+from arborista.nodes.sequences.text.string import String
 from arborista.parser import Parser
 from arborista.parsers.python.statement_parser import LibcstStatements, StatementParser
 
@@ -26,6 +27,13 @@ class ModuleParser(Parser):
     def parse_module_from_file(file_: File) -> Module:
         """Return a module from a file."""
         name: str = file_.stem
-        string: str = file_.contents
+
+        if not isinstance(file_.contents, String):
+            raise NotImplementedError
+
+        string_node = file_.contents
+        string: str = string_node.value
+
         module: Module = ModuleParser.parse_module(name, string)
+
         return module

--- a/tests/deparsers/file_system/test_file_deparser.py
+++ b/tests/deparsers/file_system/test_file_deparser.py
@@ -7,6 +7,7 @@ import pytest
 from arborista.deparser import Deparser
 from arborista.deparsers.file_system.file_deparser import FileDeparser
 from arborista.nodes.file_system.file import File
+from arborista.nodes.sequences.text.string import String
 
 
 def test_inheritance() -> None:
@@ -16,7 +17,7 @@ def test_inheritance() -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('file_', [
-    (File(Path('foo'), 'bar')),
+    (File(Path('foo'), String('bar'))),
 ])
 # yapf: enable
 def test_deparse_file(file_: File) -> None:

--- a/tests/nodes/file_system/test_file.py
+++ b/tests/nodes/file_system/test_file.py
@@ -6,6 +6,7 @@ import pytest
 
 from arborista.node import Node
 from arborista.nodes.file_system.file import File
+from arborista.nodes.sequences.text.string import String
 
 
 def test_inheritance() -> None:
@@ -15,16 +16,16 @@ def test_inheritance() -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('path, contents, parent, pass_parent, expected_path, expected_contents', [
-    (Path('foo'), '', None, False, Path('foo'), ''),
-    (Path('foo'), '', None, True, Path('foo'), ''),
-    (Path('foo'), 'bar', None, False, Path('foo'), 'bar'),
-    (Path('foo'), 'bar', None, True, Path('foo'), 'bar'),
-    (Path('foo/bar'), 'baz', None, False, Path('foo/bar'), 'baz'),
-    (Path('foo/bar'), 'baz', None, True, Path('foo/bar'), 'baz'),
+    (Path('foo'), String(), None, False, Path('foo'), String()),
+    (Path('foo'), String(), None, True, Path('foo'), String()),
+    (Path('foo'), String('bar'), None, False, Path('foo'), String('bar')),
+    (Path('foo'), String('bar'), None, True, Path('foo'), String('bar')),
+    (Path('foo/bar'), String('baz'), None, False, Path('foo/bar'), String('baz')),
+    (Path('foo/bar'), String('baz'), None, True, Path('foo/bar'), String('baz')),
 ])
 # yapf: enable
 # pylint: disable=too-many-arguments
-def test_init(path: Path, contents: str, parent: Optional[Node], pass_parent: bool,
+def test_init(path: Path, contents: Node, parent: Optional[Node], pass_parent: bool,
               expected_path: Path, expected_contents: str) -> None:
     """Test arborista.nodes.file_system.file.File.__init__."""
     keyword_arguments: Dict[str, Any] = {}
@@ -40,12 +41,12 @@ def test_init(path: Path, contents: str, parent: Optional[Node], pass_parent: bo
 
 # yapf: disable
 @pytest.mark.parametrize('file_, other, expected_equality', [
-    (File(Path('foo'), ''), 'bar', False),
-    (File(Path('foo'), 'bar'), File(Path('baz'), 'bar'), False),
-    (File(Path('foo'), 'bar'), File(Path('foo'), 'baz'), False),
-    (File(Path('foo'), 'bar'), File(Path('foo'), 'bar'), True),
-    (File(Path('foo'), 'bar'), File(Path('foo/../foo'), 'bar'), True),
-    (File(Path('foo/../foo'), 'bar'), File(Path('foo'), 'bar'), True),
+    (File(Path('foo'), String()), 'bar', False),
+    (File(Path('foo'), String('bar')), File(Path('baz'), String('bar')), False),
+    (File(Path('foo'), String('bar')), File(Path('foo'), String('baz')), False),
+    (File(Path('foo'), String('bar')), File(Path('foo'), String('bar')), True),
+    (File(Path('foo'), String('bar')), File(Path('foo/../foo'), String('bar')), True),
+    (File(Path('foo/../foo'), String('bar')), File(Path('foo'), String('bar')), True),
 ])
 # yapf: enable
 def test_eq(file_: File, other: Any, expected_equality: bool) -> None:
@@ -56,10 +57,10 @@ def test_eq(file_: File, other: Any, expected_equality: bool) -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('file_, expected_stem', [
-    (File(Path('foo'), ''), 'foo'),
-    (File(Path('foo.py'), ''), 'foo'),
-    (File(Path('foo/bar'), ''), 'bar'),
-    (File(Path('foo/bar.py'), ''), 'bar'),
+    (File(Path('foo'), String()), 'foo'),
+    (File(Path('foo.py'), String()), 'foo'),
+    (File(Path('foo/bar'), String()), 'bar'),
+    (File(Path('foo/bar.py'), String()), 'bar'),
 ])
 # yapf: enable
 def test_stem(file_: File, expected_stem: str) -> None:

--- a/tests/nodes/sequences/text/test_string.py
+++ b/tests/nodes/sequences/text/test_string.py
@@ -1,5 +1,5 @@
 """Test arborista.nodes.sequences.text.string."""
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 

--- a/tests/parsers/file_system/test_file_parser.py
+++ b/tests/parsers/file_system/test_file_parser.py
@@ -5,6 +5,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from arborista.nodes.file_system.file import File
+from arborista.nodes.sequences.text.string import String
 from arborista.parser import Parser
 from arborista.parsers.file_system.file_parser import FileParser
 
@@ -16,7 +17,7 @@ def test_inheritance() -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('file_path, file_contents, expected_file', [
-    (Path('foo'), 'bar', File(Path('foo'), 'bar')),
+    (Path('foo'), 'bar', File(Path('foo'), String('bar'))),
 ])
 # yapf: enable
 def test_parse_file(file_path: Path, file_contents: str, expected_file: File) -> None:

--- a/tests/parsers/python/test_module_parser.py
+++ b/tests/parsers/python/test_module_parser.py
@@ -9,6 +9,7 @@ from arborista.nodes.python.module import Module
 from arborista.nodes.python.name import Name
 from arborista.nodes.python.return_statement import ReturnStatement
 from arborista.nodes.python.simple_statement import SimpleStatement
+from arborista.nodes.sequences.text.string import String
 from arborista.parser import Parser
 from arborista.parsers.python.module_parser import ModuleParser
 from testing_helpers.assert_parent_set_in_children import assert_parent_set_in_children
@@ -36,8 +37,8 @@ def test_parse_module(string: str, name: str, expected_module: Module) -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('file_, expected_module', [
-    (File(Path('foo.py'), ''), Module('foo')),
-    (File(Path('foo.py'), 'def f(): return'), Module('foo', [FunctionDefinition(name=Name('f'), parameters=[], body=SimpleStatement([ReturnStatement()]))])),
+    (File(Path('foo.py'), String()), Module('foo')),
+    (File(Path('foo.py'), String('def f(): return')), Module('foo', [FunctionDefinition(name=Name('f'), parameters=[], body=SimpleStatement([ReturnStatement()]))])),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_module_from_file(file_: File, expected_module: Module) -> None:


### PR DESCRIPTION
Change the type of the file contents to be a node.

This is needed in order to be able to convert parsing and deparsing into
transformations. (This means that some of the existing parsing and
deparsing code which was changed here in maybe not the most elegant way
will be removed.)