### PR TITLE
Make tests better follow build operate check

### DIFF
--- a/tests/deparsers/python/test_block_deparser.py
+++ b/tests/deparsers/python/test_block_deparser.py
@@ -26,4 +26,5 @@ def test_inheritance() -> None:
 def test_deparse_block(block: Block, indent: str, expected_string: str) -> None:
     """Test arborista.deparsers.python.block_deparser.BlockDeparser.deparse_block."""
     string: str = BlockDeparser.deparse_block(block, indent)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_break_statement_deparser.py
+++ b/tests/deparsers/python/test_break_statement_deparser.py
@@ -19,4 +19,5 @@ def test_inheritance() -> None:
 def test_deparse_break_statement(break_statement: BreakStatement, expected_string: str) -> None:
     """Test arborista.deparsers.python.break_statement_deparser.BreakStatementDeparser.deparse_break_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = BreakStatementDeparser.deparse_break_statement(break_statement)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_compound_statement_deparser.py
+++ b/tests/deparsers/python/test_compound_statement_deparser.py
@@ -26,4 +26,5 @@ def test_deparse_compound_statement(compound_statement: CompoundStatement, inden
                                     expected_string: str) -> None:
     """Test arborista.deparsers.python.compound_statement_deparser.CompoundStatementDeparser.deparse_compound_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = CompoundStatementDeparser.deparse_compound_statement(compound_statement, indent)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_continue_statement_deparser.py
+++ b/tests/deparsers/python/test_continue_statement_deparser.py
@@ -20,4 +20,5 @@ def test_deparse_continue_statement(continue_statement: ContinueStatement,
                                     expected_string: str) -> None:
     """Test arborista.deparsers.python.continue_statement_deparser.ContinueStatementDeparser.deparse_continue_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = ContinueStatementDeparser.deparse_continue_statement(continue_statement)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_flow_statement_deparser.py
+++ b/tests/deparsers/python/test_flow_statement_deparser.py
@@ -24,4 +24,5 @@ def test_inheritance() -> None:
 def test_deparse_flow_statement(flow_statement: FlowStatement, expected_string: str) -> None:
     """Test arborista.deparsers.python.flow_statement_deparser.FlowStatementDeparser.deparse_flow_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = FlowStatementDeparser.deparse_flow_statement(flow_statement)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_function_definition_deparser.py
+++ b/tests/deparsers/python/test_function_definition_deparser.py
@@ -34,4 +34,5 @@ def test_deparse_function_definition(function_definition: FunctionDefinition, in
     """Test arborista.deparsers.python.function_definition_deparser.FunctionDefinitionDeparser.deparse_function_definition."""  # pylint: disable=line-too-long, useless-suppression
     string: str = FunctionDefinitionDeparser.deparse_function_definition(
         function_definition, indent)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_module_deparser.py
+++ b/tests/deparsers/python/test_module_deparser.py
@@ -27,4 +27,5 @@ def test_inheritance() -> None:
 def test_deparse_module(module: Module, expected_string: str) -> None:
     """Test arborista.deparsers.python.module_deparser.ModuleDeparser.deparse_module."""
     string: str = ModuleDeparser.deparse_module(module)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_name_deparser.py
+++ b/tests/deparsers/python/test_name_deparser.py
@@ -19,4 +19,5 @@ def test_inheritance() -> None:
 def test_deparse_name(name: Name, expected_string: str) -> None:
     """Test arborista.deparsers.python.name_deparser.NameDeparser.deparse_name."""
     string: str = NameDeparser.deparse_name(name)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_parameter_deparser.py
+++ b/tests/deparsers/python/test_parameter_deparser.py
@@ -20,4 +20,5 @@ def test_inheritance() -> None:
 def test_deparse_parameter(parameter: Parameter, expected_string: str) -> None:
     """Test arborista.deparsers.python.parameter_deparser.ParameterDeparser.deparse_parameter."""
     string: str = ParameterDeparser.deparse_parameter(parameter)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_pass_statement_deparser.py
+++ b/tests/deparsers/python/test_pass_statement_deparser.py
@@ -19,4 +19,5 @@ def test_inheritance() -> None:
 def test_deparse_pass_statement(pass_statement: PassStatement, expected_string: str) -> None:
     """Test arborista.deparsers.python.pass_statement_deparser.PassStatementDeparser.deparse_pass_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = PassStatementDeparser.deparse_pass_statement(pass_statement)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_return_statement_deparser.py
+++ b/tests/deparsers/python/test_return_statement_deparser.py
@@ -19,4 +19,5 @@ def test_inheritance() -> None:
 def test_deparse_return_statement(return_statement: ReturnStatement, expected_string: str) -> None:
     """Test arborista.deparsers.python.return_statement_deparser.ReturnStatementDeparser.deparse_return_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = ReturnStatementDeparser.deparse_return_statement(return_statement)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_simple_statement_deparser.py
+++ b/tests/deparsers/python/test_simple_statement_deparser.py
@@ -29,4 +29,5 @@ def test_deparse_simple_statement(simple_statement: SimpleStatement, indent: str
                                   expected_string: str) -> None:
     """Test arborista.deparsers.python.simple_statement_deparser.SimpleStatementDeparser.deparse_simple_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = SimpleStatementDeparser.deparse_simple_statement(simple_statement, indent)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_small_statement_deparser.py
+++ b/tests/deparsers/python/test_small_statement_deparser.py
@@ -22,4 +22,5 @@ def test_inheritance() -> None:
 def test_deparser_small_statement(small_statement: SmallStatement, expected_string: str) -> None:
     """Test arborista.deparsers.python.small_statement_deparser.SmallStatementDeparser.deparse_small_statement."""  # pylint: disable=line-too-long, useless-suppression
     string: str = SmallStatementDeparser.deparse_small_statement(small_statement)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_statement_deparser.py
+++ b/tests/deparsers/python/test_statement_deparser.py
@@ -25,4 +25,5 @@ def test_inheritance() -> None:
 def test_deparse_statement(statement: Statement, indent: str, expected_string: str) -> None:
     """Test arborista.deparsers.python.statement_deparser.StatementDeparser.deparse_statement."""
     string: str = StatementDeparser.deparse_statement(statement, indent)
+
     assert string == expected_string

--- a/tests/deparsers/python/test_suite_deparser.py
+++ b/tests/deparsers/python/test_suite_deparser.py
@@ -27,4 +27,5 @@ def test_inheritance() -> None:
 def test_deparse_suite(suite: Suite, indent: str, expected_string: str) -> None:
     """Test arborista.deparsers.python.suite_deparser.SuiteDeparser.deparse_suite."""
     string: str = SuiteDeparser.deparse_suite(suite, indent)
+
     assert string == expected_string

--- a/tests/nodes/file_system/test_file.py
+++ b/tests/nodes/file_system/test_file.py
@@ -53,6 +53,7 @@ def test_init(path: Path, contents: Node, parent: Optional[Node], pass_parent: b
 def test_eq(file_: File, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.file_system.file.File.__eq__."""
     equality: bool = file_ == other
+
     assert equality == expected_equality
 
 
@@ -66,6 +67,7 @@ def test_iterate_children(file_: File, expected_children_list: NodeList) -> None
     """Test arborista.nodes.file_system.file.File.iterate_children."""
     children: NodeIterator = file_.iterate_children()
     children_list: NodeList = list(children)
+
     assert children_list == expected_children_list
 
 

--- a/tests/nodes/python/test_block.py
+++ b/tests/nodes/python/test_block.py
@@ -70,6 +70,7 @@ def test_init(body: Statements, expected_body: StatementList, indent: str, paren
 def test_eq(block: Block, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.block.Block.__eq__."""
     equality: bool = block == other
+
     assert equality == expected_equality
 
 
@@ -84,4 +85,5 @@ def test_iterate_children(block: Block, expected_children_list: NodeList) -> Non
     """Test arborista.nodes.python.block.Block.iterate_children."""
     children: NodeIterator = block.iterate_children()
     children_list: NodeList = list(children)
+
     assert children_list == expected_children_list

--- a/tests/nodes/python/test_break_statement.py
+++ b/tests/nodes/python/test_break_statement.py
@@ -21,4 +21,5 @@ def test_inheritance() -> None:
 def test_eq(break_statement: BreakStatement, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.break_statement.BreakStatement.__eq__."""
     equality: bool = break_statement == other
+
     assert equality == expected_equality

--- a/tests/nodes/python/test_continue_statement.py
+++ b/tests/nodes/python/test_continue_statement.py
@@ -21,4 +21,5 @@ def test_inheritance() -> None:
 def test_eq(continue_statement: ContinueStatement, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.continue_statement.ContinueStatement.__eq__."""
     equality: bool = continue_statement == other
+
     assert equality == expected_equality

--- a/tests/nodes/python/test_function_definition.py
+++ b/tests/nodes/python/test_function_definition.py
@@ -66,6 +66,7 @@ def test_function_definition_init(name: Name, parameters: Parameters, body: Suit
 def test_eq(function_definition: FunctionDefinition, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.function_definition.__eq__."""
     equality: bool = function_definition == other
+
     assert equality == expected_equality
 
 
@@ -83,4 +84,5 @@ def test_iterate_children(function_definition: FunctionDefinition,
     """Test arborista.nodes.python.function_definition.iterate_children."""
     children: NodeIterator = function_definition.iterate_children()
     children_list: NodeList = list(children)
+
     assert children_list == expected_children_list

--- a/tests/nodes/python/test_module.py
+++ b/tests/nodes/python/test_module.py
@@ -61,6 +61,7 @@ def test_module_init(name: str, statements: Optional[Statements], pass_statement
 def test_eq(module: Module, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.module.__eq__."""
     equality: bool = module == other
+
     assert equality == expected_equality
 
 
@@ -74,4 +75,5 @@ def test_iterate_children(module: Module, expected_children_list: NodeList) -> N
     """Test arborista.nodes.python.module.iterate_children."""
     children: NodeIterator = module.iterate_children()
     children_list: NodeList = list(children)
+
     assert children_list == expected_children_list

--- a/tests/nodes/python/test_name.py
+++ b/tests/nodes/python/test_name.py
@@ -42,4 +42,5 @@ def test_init(value: str, parent: Optional[Node], pass_parent: bool) -> None:
 def test_eq(name: Name, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.name.__eq__."""
     equality: bool = name == other
+
     assert equality == expected_equality

--- a/tests/nodes/python/test_parameter.py
+++ b/tests/nodes/python/test_parameter.py
@@ -44,6 +44,7 @@ def test_init(name: Name, parent: Optional[Node], pass_parent: bool) -> None:
 def test_eq(parameter: Parameter, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.parameter.Parameter.__eq__."""
     equality: bool = parameter == other
+
     assert equality == expected_equality
 
 
@@ -56,4 +57,5 @@ def test_iterate_children(parameter: Parameter, expected_children_list: NodeList
     """Test arborista.nodes.python.parameter.Parameter.iterate_children."""
     children: NodeIterator = parameter.iterate_children()
     children_list: NodeList = list(children)
+
     assert children_list == expected_children_list

--- a/tests/nodes/python/test_pass_statement.py
+++ b/tests/nodes/python/test_pass_statement.py
@@ -21,4 +21,5 @@ def test_inheritance() -> None:
 def test_eq(pass_statement: PassStatement, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.pass_statement.PassStatement.__eq__."""
     equality: bool = pass_statement == other
+
     assert equality == expected_equality

--- a/tests/nodes/python/test_return_statement.py
+++ b/tests/nodes/python/test_return_statement.py
@@ -21,4 +21,5 @@ def test_inheritance() -> None:
 def test_eq(return_statement: ReturnStatement, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.return_statement.ReturnStatement.__eq__."""
     equality: bool = return_statement == other
+
     assert equality == expected_equality

--- a/tests/nodes/python/test_simple_statement.py
+++ b/tests/nodes/python/test_simple_statement.py
@@ -45,6 +45,7 @@ def test_simple_statement_init(small_statements: SmallStatements, parent: Option
 def test_eq(simple_statement: SimpleStatement, other: Any, expected_equality: bool) -> None:
     """Test arborista.nodes.python.simple_statement.__eq__."""
     equality: bool = simple_statement == other
+
     assert equality == expected_equality
 
 
@@ -60,4 +61,5 @@ def test_iterate_children(simple_statement: SimpleStatement,
     """Test arborista.nodes.python.simple_statement.iterate_children."""
     children: NodeIterator = simple_statement.iterate_children()
     children_list: NodeList = list(children)
+
     assert children_list == expected_children_list

--- a/tests/parsers/python/test_break_statement_parser.py
+++ b/tests/parsers/python/test_break_statement_parser.py
@@ -23,4 +23,5 @@ def test_parse_break_statement(libcst_break_statement: LibcstBreakStatement,
     """Test arborista.parsers.python.break_statement_parser.BreakStatementParser.parse_break_statement."""  # pylint: disable=line-too-long, useless-suppression
     break_statement: BreakStatement = BreakStatementParser.parse_break_statement(
         libcst_break_statement)
+
     assert break_statement == expected_break_statement

--- a/tests/parsers/python/test_compound_statement_parser.py
+++ b/tests/parsers/python/test_compound_statement_parser.py
@@ -28,4 +28,5 @@ def test_parse_compound_statement(libcst_compound_statement: LibcstCompoundState
     """Test arborista.parsers.python.compound_statement_parser.CompoundStatementParser.parse_compound_statement."""  # pylint: disable=line-too-long, useless-suppression
     compound_statement: CompoundStatement = CompoundStatementParser.parse_compound_statement(
         libcst_compound_statement)
+
     assert compound_statement == expected_compound_statement

--- a/tests/parsers/python/test_continue_statement_parser.py
+++ b/tests/parsers/python/test_continue_statement_parser.py
@@ -23,4 +23,5 @@ def test_parse_continue_statement(libcst_continue_statement: LibcstContinueState
     """Test arborista.parsers.python.continue_statement_parser.ContinueStatementParser.parse_continue_statement."""  # pylint: disable=line-too-long, useless-suppression
     continue_statement: ContinueStatement = ContinueStatementParser.parse_continue_statement(
         libcst_continue_statement)
+
     assert continue_statement == expected_continue_statement

--- a/tests/parsers/python/test_flow_statement_parser.py
+++ b/tests/parsers/python/test_flow_statement_parser.py
@@ -26,4 +26,5 @@ def test_parse_flow_statement(libcst_flow_statement: LibcstFlowStatement,
                               expected_flow_statement: FlowStatement) -> None:
     """Test arborista.parsers.python.flow_statement_parser.FlowStatementParser.parse_flow_statement."""  # pylint: disable=line-too-long, useless-suppression
     flow_statement: FlowStatement = FlowStatementParser.parse_flow_statement(libcst_flow_statement)
+
     assert flow_statement == expected_flow_statement

--- a/tests/parsers/python/test_name_parser.py
+++ b/tests/parsers/python/test_name_parser.py
@@ -20,4 +20,5 @@ def test_inheritance() -> None:
 def test_parse_name(libcst_name: LibcstName, expected_name: Name) -> None:
     """Test arborista.parsers.python.name_parser.NameParser.parse_name."""
     name: Name = NameParser.parse_name(libcst_name)
+
     assert name == expected_name

--- a/tests/parsers/python/test_pass_statement_parser.py
+++ b/tests/parsers/python/test_pass_statement_parser.py
@@ -21,4 +21,5 @@ def test_parse_pass_statement(libcst_pass_statement: LibcstPassStatement,
                               expected_pass_statement: PassStatement) -> None:
     """Test arborista.parsers.python.pass_statement_parser.PassStatementParser.parse_pass_statement."""  # pylint: disable=line-too-long, useless-suppression
     pass_statement: PassStatement = PassStatementParser.parse_pass_statement(libcst_pass_statement)
+
     assert pass_statement == expected_pass_statement

--- a/tests/parsers/python/test_return_statement_parser.py
+++ b/tests/parsers/python/test_return_statement_parser.py
@@ -23,4 +23,5 @@ def test_parse_return_statement(libcst_return_statement: LibcstReturnStatement,
     """Test arborista.parsers.python.return_statement_parser.ReturnStatementParser.parse_return_statement."""  # pylint: disable=line-too-long, useless-suppression
     return_statement: ReturnStatement = ReturnStatementParser.parse_return_statement(
         libcst_return_statement)
+
     assert return_statement == expected_return_statement

--- a/tests/parsers/python/test_small_statement_parser.py
+++ b/tests/parsers/python/test_small_statement_parser.py
@@ -27,6 +27,7 @@ def test_parse_small_statement(libcst_small_statement: LibcstSmallStatement,
     """Test arborista.parsers.python.small_statement_parser.SmallStatementParser.parse_small_statement."""  # pylint: disable=line-too-long, useless-suppression
     small_statement: SmallStatement = SmallStatementParser.parse_small_statement(
         libcst_small_statement)
+
     assert small_statement == expected_small_statement
 
 
@@ -40,4 +41,5 @@ def test_parse_small_statements(libcst_small_statements: LibcstSmallStatements,
     """Test arborista.parsers.python.small_statement_parser.SmallStatementParser.parse_small_statements."""  # pylint: disable=line-too-long, useless-suppression
     small_statements: SmallStatementList = SmallStatementParser.parse_small_statements(
         libcst_small_statements)
+
     assert small_statements == expected_small_statements

--- a/tests/parsers/python/test_statement_parser.py
+++ b/tests/parsers/python/test_statement_parser.py
@@ -23,6 +23,7 @@ def test_inheritance() -> None:
 def test_parse_statement(libcst_statement: LibcstStatement, expected_statement: Statement) -> None:
     """Test arborista.parsers.python.statement_parser.StatementParser.parse_statements."""
     statement: Statement = StatementParser.parse_statement(libcst_statement)
+
     assert statement == expected_statement
 
 
@@ -35,4 +36,5 @@ def test_parse_statements(libcst_statements: LibcstStatements,
                           expected_statements: StatementList) -> None:
     """Test arborista.parsers.python.statement_parser.StatementParser.parse_statements."""
     statements: StatementList = StatementParser.parse_statements(libcst_statements)
+
     assert statements == expected_statements

--- a/tests/parsers/python/test_suite_parser.py
+++ b/tests/parsers/python/test_suite_parser.py
@@ -24,4 +24,5 @@ def test_inheritance() -> None:
 def test_parse_suite(libcst_suite: LibcstSuite, expected_suite: Suite) -> None:
     """Test arborista.parsers.python.suite_parser.SuiteParser.parse_suite."""
     suite: Suite = SuiteParser.parse_suite(libcst_suite)
+
     assert suite == expected_suite

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -220,7 +220,6 @@ def test_main(argument_parser: argparse.ArgumentParser, parsed_arguments: argpar
         return_value: int = main(arguments)
 
         _assert_main_return_value(return_value)
-
         set_up_argument_parser_mock.assert_called_once()
         parse_arguments_mock.assert_called_once_with(argument_parser, arguments)
         set_up_logging_mock.assert_called_once()

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -34,7 +34,9 @@ def test_node_init(parent: Optional[Node], pass_parent: bool,
 def test_node_iterate_children() -> None:
     """Test arborista.node.iterate_children."""
     node: Node = Node()
+
     children_iterator: Iterator[Node] = node.iterate_children()
+
     assert list(children_iterator) == []
 
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -46,6 +46,7 @@ def test_init(root: Optional[Node], pass_root: bool, expected_root: Optional[Nod
 def test_eq(tree: Tree, other: Any, expected_equality: bool) -> None:
     """Test arborista.tree.Tree.__eq__."""
     equality: bool = tree == other
+
     assert equality == expected_equality
 
 

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -32,6 +32,7 @@ def test_iter(tree: Tree) -> None:
     walk: Walk = Walk(tree)
 
     steps: NodeIterator = iter(walk)
+
     assert steps == walk
 
 


### PR DESCRIPTION
Make test better follow the build-operate-check pattern by adding blank
lines to emphasize the seperation of the three parts of a test.