### PR TITLE
Add node equality operator

### DIFF
--- a/arborista/node.py
+++ b/arborista/node.py
@@ -1,11 +1,12 @@
 """A node in a tree."""
 import collections
-from typing import Iterable, Iterator, List, Optional, Sequence, Set, Type, Union
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Iterator, List, Optional, Sequence, Set, Type, Union
 
 from arborista.exceptions.unexpected_node_type_exception import UnexpectedNodeTypeException
 
 
-class Node():
+class Node(ABC):
     """A node in a tree."""
     def __init__(self, parent: Optional['Node'] = None):
         self.parent: Optional['Node'] = parent
@@ -14,6 +15,10 @@ class Node():
         """Yield children of this node."""
         nodes: NodeList = []
         return iter(nodes)
+
+    @abstractmethod
+    def __eq__(self, other: Any) -> bool:
+        raise NotImplementedError
 
     def assert_is_type(self, node_types: Union['NodeType', 'NodeTypes']) -> None:
         """Raise an exception if type of the node is not one of the given node types."""

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,5 +1,6 @@
 """Test arborista.node."""
 from typing import Any, Dict, Iterator, Optional, Type, Union
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,16 +27,30 @@ def test_node_init(parent: Optional[Node], pass_parent: bool,
     if pass_parent:
         keyword_arguments['parent'] = parent
 
-    node: Node = Node(**keyword_arguments)
+    mock_node = MagicMock(Node)
+    Node.__init__(mock_node, **keyword_arguments)
 
-    assert node.parent == expected_parent
+    assert mock_node.parent == expected_parent
+
+
+# yapf: disable
+@pytest.mark.parametrize('other', [
+    ('foo'),
+])
+# yapf: enable
+def test_eq(other: Any) -> None:
+    """Test arborista.node.__eq__."""
+    mock_node = MagicMock(Node, __eq__=Node.__eq__)
+
+    with pytest.raises(NotImplementedError):
+        mock_node == other  # pylint: disable=pointless-statement
 
 
 def test_node_iterate_children() -> None:
     """Test arborista.node.iterate_children."""
-    node: Node = Node()
+    mock_node = MagicMock(Node)
 
-    children_iterator: Iterator[Node] = node.iterate_children()
+    children_iterator: Iterator[Node] = Node.iterate_children(mock_node)
 
     assert list(children_iterator) == []
 

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -3,6 +3,7 @@ import pytest
 
 from arborista.node import Node
 from arborista.transformation import Transformation
+from testing_helpers.animal_nodes import Dog
 
 
 def test_node_types() -> None:
@@ -12,7 +13,7 @@ def test_node_types() -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('node', [
-    (Node())
+    (Dog())
 ])
 # yapf: enable
 def test_maybe_transform(node: Node) -> None:


### PR DESCRIPTION
Add the equality operator for nodes and make node an abstract base
class. The reason for doing this is to ensure that all nodes have an
appropriate equality operator defined. (It would probably be better
however to define a generic equality operator which checks that all
data is the type and data for the two objects being compared.)