### PR TITLE
Make pylint check all files

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,4 +10,5 @@ cd "${ARBORISTA}"
 source "${ARBORISTA}/scripts/library/venv.sh"
 use_venv "test" frozen_test_requirements.txt
 
-python3 -m pylint -j 0 arborista tests testing_helpers
+find . -path ./venvs -prune -false -o -name "*.py" | xargs python3 -m pylint -j 0
+

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""A build script using setuptools for the arborista package."""
 import setuptools
 
 with open('README.md') as readme:


### PR DESCRIPTION
Make pylint check all Python files instead of just the packages it was
passed.