### PR TITLE
Add Python comparison operator node

### DIFF
--- a/arborista/nodes/python/comparison.py
+++ b/arborista/nodes/python/comparison.py
@@ -1,0 +1,35 @@
+"""A Python comparison."""
+from typing import Any, Optional
+
+from seligimus.python.decorators.operators.equality.equal_type import equal_type
+
+from arborista.node import Node
+from arborista.nodes.python.comparison_operator import ComparisonOperator
+from arborista.nodes.python.expression import Expression
+
+
+class Comparison(Expression):
+    """A Python comparison."""
+    def __init__(self,
+                 left: Expression,
+                 comparison_operator: ComparisonOperator,
+                 right: Expression,
+                 parent: Optional[Node] = None) -> None:
+        super().__init__(parent)
+
+        self.left: Expression = left
+        self.comparison_operator: ComparisonOperator = comparison_operator
+        self.right: Expression = right
+
+    @equal_type
+    def __eq__(self, other: Any) -> bool:
+        if self.left != other.left:
+            return False
+
+        if self.comparison_operator != other.comparison_operator:
+            return False
+
+        if self.right != other.right:
+            return False
+
+        return True

--- a/tests/nodes/python/test_comparison.py
+++ b/tests/nodes/python/test_comparison.py
@@ -1,0 +1,56 @@
+"""Test arborista.nodes.python.comparison."""
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from arborista.node import Node
+from arborista.nodes.python.comparison import Comparison
+from arborista.nodes.python.comparison_operator import ComparisonOperator
+from arborista.nodes.python.expression import Expression
+from arborista.nodes.python.greater_than import GreaterThan
+from arborista.nodes.python.integer import Integer
+from arborista.nodes.python.less_than import LessThan
+
+
+def test_inheritance() -> None:
+    """Test arborista.nodes.python.comparison.Comparison inheritance."""
+    assert issubclass(Comparison, Expression)
+
+
+# yapf: disable
+@pytest.mark.parametrize('left, comparison_operator, right, parent, pass_parent', [
+    (Integer(1), LessThan(), Integer(2), None, False),
+    (Integer(1), LessThan(), Integer(2), None, True),
+    (Integer(1), LessThan(), Integer(2), MagicMock(), True),
+])
+# yapf: enable
+def test_init(left: Expression, comparison_operator: ComparisonOperator, right: Expression,
+              parent: Optional[Node], pass_parent: bool) -> None:
+    """Test arborista.nodes.python.comparison.Comparison.__init__."""
+    keyword_arguments: Dict[str, Any] = {}
+    if pass_parent:
+        keyword_arguments['parent'] = parent
+
+    comparison = Comparison(left, comparison_operator, right, **keyword_arguments)
+
+    assert comparison.left == left
+    assert comparison.comparison_operator == comparison_operator
+    assert comparison.right == right
+    assert comparison.parent is parent
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('comparison, other, expected_equality', [
+    (Comparison(Integer(1), LessThan(), Integer(2)), 'foo', False),
+    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(1), LessThan(), Integer(3)), False),
+    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(1), GreaterThan(), Integer(2)), False),
+    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(2), LessThan(), Integer(2)), False),
+    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(1), LessThan(), Integer(2)), True),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_eq(comparison: Comparison, other: Any, expected_equality: bool) -> None:
+    """Test arborista.nodes.python.comparison.Comparison.__eq__."""
+    equality: bool = comparison == other
+
+    assert equality == expected_equality


### PR DESCRIPTION
Add a Python comparison operator node. This isn't quite right because
comparisons can actually be chained like `x < y < z` but we can do that
later.