### PR TITLE
Ascola/bump seligimus to 0 13 0

### DIFF
--- a/arborista/nodes/nebnf/alternation.py
+++ b/arborista/nodes/nebnf/alternation.py
@@ -1,7 +1,5 @@
 """A choice between two righthand sides."""
-from typing import TYPE_CHECKING, Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import TYPE_CHECKING, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.nebnf_node import NEBNFNode
@@ -20,13 +18,3 @@ class Alternation(NEBNFNode):
 
         self.first_choice: 'RighthandSide' = first_choice
         self.second_choice: 'RighthandSide' = second_choice
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_choice != other.first_choice:
-            return False
-
-        if self.second_choice != other.second_choice:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/character.py
+++ b/arborista/nodes/nebnf/character.py
@@ -1,7 +1,5 @@
 """A character."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.nebnf.digit import DigitValue
@@ -19,8 +17,3 @@ class Character(NEBNFNode):
         super().__init__(parent)
 
         self.value: CharacterValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/nebnf/concatenation.py
+++ b/arborista/nodes/nebnf/concatenation.py
@@ -1,7 +1,5 @@
 """A concatenation of two righthand sides."""
-from typing import TYPE_CHECKING, Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import TYPE_CHECKING, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.nebnf_node import NEBNFNode
@@ -20,13 +18,3 @@ class Concatenation(NEBNFNode):
 
         self.first: 'RighthandSide' = first
         self.second: 'RighthandSide' = second
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first != other.first:
-            return False
-
-        if self.second != other.second:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/digit.py
+++ b/arborista/nodes/nebnf/digit.py
@@ -1,7 +1,6 @@
 """A digit."""
-from typing import Any, Optional
+from typing import Optional
 
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from typing_extensions import Literal
 
 from arborista.node import Node
@@ -16,8 +15,3 @@ class Digit(NEBNFNode):
         super().__init__(parent)
 
         self.value: DigitValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/nebnf/double_quoted_terminal.py
+++ b/arborista/nodes/nebnf/double_quoted_terminal.py
@@ -1,7 +1,5 @@
 """A double quoted terminal."""
-from typing import Any, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import List, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.character import Character
@@ -18,13 +16,3 @@ class DoubleQuotedTerminal(NEBNFNode):
 
         self.first_character: Character = first_character
         self.rest_of_characters: List[Character] = rest_of_characters
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_character != other.first_character:
-            return False
-
-        if self.rest_of_characters != other.rest_of_characters:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/grammer.py
+++ b/arborista/nodes/nebnf/grammer.py
@@ -1,7 +1,5 @@
 """An NEBNF grammer."""
-from typing import Any, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import List, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.nebnf_node import NEBNFNode
@@ -14,10 +12,3 @@ class Grammer(NEBNFNode):
         super().__init__(parent)
 
         self.rules: List[Rule] = rules
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.rules != other.rules:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/grouping.py
+++ b/arborista/nodes/nebnf/grouping.py
@@ -1,7 +1,5 @@
 """An grouping righthand side."""
-from typing import TYPE_CHECKING, Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import TYPE_CHECKING, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.name import Name
@@ -21,13 +19,3 @@ class Grouping(NEBNFNode):
 
         self.name: Optional[Name] = name
         self.righthand_side: 'RighthandSide' = righthand_side
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name != other.name:
-            return False
-
-        if self.righthand_side != other.righthand_side:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/identifier.py
+++ b/arborista/nodes/nebnf/identifier.py
@@ -1,7 +1,5 @@
 """An identifier."""
-from typing import Any, List, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import List, Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.nebnf.digit import Digit
@@ -21,13 +19,3 @@ class Identifier(NEBNFNode):
         self.first_character: UppercaseLetter = first_character
         self.rest_of_characters: List[Union[LowercaseLetter, UppercaseLetter,
                                             Digit]] = rest_of_characters
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_character != other.first_character:
-            return False
-
-        if self.rest_of_characters != other.rest_of_characters:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/lefthand_side.py
+++ b/arborista/nodes/nebnf/lefthand_side.py
@@ -1,7 +1,5 @@
 """The lefthand side of a production rule."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.identifier import Identifier
@@ -14,8 +12,3 @@ class LefthandSide(NEBNFNode):
         super().__init__(parent)
 
         self.identifier: Identifier = identifier
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.identifier == other.identifier
-        return equality

--- a/arborista/nodes/nebnf/letter.py
+++ b/arborista/nodes/nebnf/letter.py
@@ -1,7 +1,5 @@
 """A letter."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.nebnf.lowercase_letter import LowercaseLetterValue
@@ -17,8 +15,3 @@ class Letter(NEBNFNode):
         super().__init__(parent)
 
         self.value: LetterValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/nebnf/lowercase_letter.py
+++ b/arborista/nodes/nebnf/lowercase_letter.py
@@ -1,7 +1,6 @@
 """A lowercase letter."""
-from typing import Any, Optional
+from typing import Optional
 
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from typing_extensions import Literal
 
 from arborista.node import Node
@@ -17,8 +16,3 @@ class LowercaseLetter(NEBNFNode):
         super().__init__(parent)
 
         self.value: LowercaseLetterValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/nebnf/name.py
+++ b/arborista/nodes/nebnf/name.py
@@ -1,7 +1,5 @@
 """A name for a part of an expression."""
-from typing import Any, List, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import List, Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.nebnf.digit import Digit
@@ -21,13 +19,3 @@ class Name(NEBNFNode):
         self.first_character: LowercaseLetter = first_character
         self.rest_of_characters: List[Union[LowercaseLetter, Digit,
                                             Underscore]] = rest_of_characters
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_character != other.first_character:
-            return False
-
-        if self.rest_of_characters != other.rest_of_characters:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/nebnf_node.py
+++ b/arborista/nodes/nebnf/nebnf_node.py
@@ -1,8 +1,17 @@
 """A Named Extended Backus-Naur Form node."""
 from abc import ABC
+from typing import Any
+
+from seligimus.python.decorators.operators.equality.equal_instance_attributes import \
+    equal_instance_attributes
+from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.node import Node
 
 
 class NEBNFNode(Node, ABC):
     """A Named Extended Backus-Naur Form node."""
+    @equal_type
+    @equal_instance_attributes(excludes={'parent'})
+    def __eq__(self, other: Any) -> bool:
+        return True

--- a/arborista/nodes/nebnf/option.py
+++ b/arborista/nodes/nebnf/option.py
@@ -1,7 +1,5 @@
 """An optional righthand side."""
-from typing import TYPE_CHECKING, Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import TYPE_CHECKING, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.name import Name
@@ -21,13 +19,3 @@ class Option(NEBNFNode):
 
         self.name: Optional[Name] = name
         self.righthand_side: 'RighthandSide' = righthand_side
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name != other.name:
-            return False
-
-        if self.righthand_side != other.righthand_side:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/repetition.py
+++ b/arborista/nodes/nebnf/repetition.py
@@ -1,7 +1,5 @@
 """A repetition of righthand sides."""
-from typing import TYPE_CHECKING, Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import TYPE_CHECKING, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.name import Name
@@ -21,13 +19,3 @@ class Repetition(NEBNFNode):
 
         self.name: Optional[Name] = name
         self.element: 'RighthandSide' = element
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name != other.name:
-            return False
-
-        if self.element != other.element:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/righthand_side.py
+++ b/arborista/nodes/nebnf/righthand_side.py
@@ -1,7 +1,5 @@
 """The righthand side of a production rule."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.nebnf.alternation import Alternation
@@ -22,8 +20,3 @@ class RighthandSide(NEBNFNode):
         super().__init__(parent)
 
         self.expression: Expression = expression
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.expression == other.expression
-        return equality

--- a/arborista/nodes/nebnf/rule.py
+++ b/arborista/nodes/nebnf/rule.py
@@ -1,7 +1,5 @@
 """A production rule."""
-from typing import TYPE_CHECKING, Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import TYPE_CHECKING, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.lefthand_side import LefthandSide
@@ -21,13 +19,3 @@ class Rule(NEBNFNode):
 
         self.lefthand_side: LefthandSide = lefthand_side
         self.righthand_side: 'RighthandSide' = righthand_side
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.righthand_side != other.righthand_side:
-            return False
-
-        if self.lefthand_side != other.lefthand_side:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/single_quoted_terminal.py
+++ b/arborista/nodes/nebnf/single_quoted_terminal.py
@@ -1,7 +1,5 @@
 """A single quoted terminal."""
-from typing import Any, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import List, Optional
 
 from arborista.node import Node
 from arborista.nodes.nebnf.character import Character
@@ -18,13 +16,3 @@ class SingleQuotedTerminal(NEBNFNode):
 
         self.first_character: Character = first_character
         self.rest_of_characters: List[Character] = rest_of_characters
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_character != other.first_character:
-            return False
-
-        if self.rest_of_characters != other.rest_of_characters:
-            return False
-
-        return True

--- a/arborista/nodes/nebnf/symbol.py
+++ b/arborista/nodes/nebnf/symbol.py
@@ -1,7 +1,6 @@
 """A symbol."""
-from typing import Any, Optional
+from typing import Optional
 
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from typing_extensions import Literal
 
 from arborista.node import Node
@@ -16,8 +15,3 @@ class Symbol(NEBNFNode):
         super().__init__(parent)
 
         self.value: SymbolValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/nebnf/terminal.py
+++ b/arborista/nodes/nebnf/terminal.py
@@ -1,7 +1,5 @@
 """A terminal."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.nebnf.double_quoted_terminal import DoubleQuotedTerminal
@@ -17,8 +15,3 @@ class Terminal(NEBNFNode):
         super().__init__(parent)
 
         self.value: TerminalValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/nebnf/underscore.py
+++ b/arborista/nodes/nebnf/underscore.py
@@ -1,7 +1,6 @@
 """An underscore."""
-from typing import Any, Optional
+from typing import Optional
 
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from typing_extensions import Literal
 
 from arborista.node import Node
@@ -16,7 +15,3 @@ class Underscore(NEBNFNode):
         super().__init__(parent)
 
         self.value: UnderscoreValue = '_'
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/nebnf/uppercase_letter.py
+++ b/arborista/nodes/nebnf/uppercase_letter.py
@@ -1,7 +1,6 @@
 """A uppercase letter."""
-from typing import Any, Optional
+from typing import Optional
 
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from typing_extensions import Literal
 
 from arborista.node import Node
@@ -17,8 +16,3 @@ class UppercaseLetter(NEBNFNode):
         super().__init__(parent)
 
         self.value: UppercaseLetterValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/python/and_.py
+++ b/arborista/nodes/python/and_.py
@@ -1,5 +1,5 @@
 """A Python and operator."""
-from typing import Any, Optional
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.boolean_operator import BooleanOperator
@@ -9,6 +9,3 @@ class And(BooleanOperator):
     """A Python and operator."""
     def __init__(self, parent: Optional[Node] = None):
         super().__init__(parent)
-
-    def __eq__(self, other: Any) -> bool:
-        return isinstance(other, And)

--- a/arborista/nodes/python/block.py
+++ b/arborista/nodes/python/block.py
@@ -1,7 +1,5 @@
 """A Python block."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node, NodeIterator
 from arborista.nodes.python.python_node import PythonNode
@@ -15,11 +13,6 @@ class Block(PythonNode):
 
         self.body: StatementList = list(body)
         self.indent: str = indent
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.body == other.body
-        return equality
 
     def iterate_children(self) -> NodeIterator:
         yield from self.body

--- a/arborista/nodes/python/boolean_operation.py
+++ b/arborista/nodes/python/boolean_operation.py
@@ -1,7 +1,5 @@
 """A Python boolean operation."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node, NodeIterator
 from arborista.nodes.python.boolean_operator import BooleanOperator
@@ -20,12 +18,6 @@ class BooleanOperation(Expression):
         self.left: Expression = left
         self.operator: BooleanOperator = operator
         self.right: Expression = right
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = (self.left == other.left and self.operator == other.operator
-                          and self.right == other.right)
-        return equality
 
     def iterate_children(self) -> NodeIterator:
         yield self.left

--- a/arborista/nodes/python/break_statement.py
+++ b/arborista/nodes/python/break_statement.py
@@ -1,13 +1,7 @@
 """A Python break statement."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.flow_statement import FlowStatement
 
 
 class BreakStatement(FlowStatement):
     """A Python break statement."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/comparison.py
+++ b/arborista/nodes/python/comparison.py
@@ -1,7 +1,5 @@
 """A Python comparison."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.comparison_operator import ComparisonOperator
@@ -20,16 +18,3 @@ class Comparison(Expression):
         self.left: Expression = left
         self.comparison_operator: ComparisonOperator = comparison_operator
         self.right: Expression = right
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.left != other.left:
-            return False
-
-        if self.comparison_operator != other.comparison_operator:
-            return False
-
-        if self.right != other.right:
-            return False
-
-        return True

--- a/arborista/nodes/python/continue_statement.py
+++ b/arborista/nodes/python/continue_statement.py
@@ -1,13 +1,7 @@
 """A Python continue statement."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.flow_statement import FlowStatement
 
 
 class ContinueStatement(FlowStatement):
     """A Python continue statement."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/dotted_name.py
+++ b/arborista/nodes/python/dotted_name.py
@@ -1,7 +1,5 @@
 """A Python dotted name."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.import_statement import ImportStatement
@@ -15,13 +13,3 @@ class DottedName(ImportStatement):
 
         self.first_name: Name = first_name
         self.rest_of_names: Names = rest_of_names
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_name != other.first_name:
-            return False
-
-        if self.rest_of_names != other.rest_of_names:
-            return False
-
-        return True

--- a/arborista/nodes/python/dotted_name_as_name.py
+++ b/arborista/nodes/python/dotted_name_as_name.py
@@ -1,7 +1,5 @@
 """A Python dotted name as another name."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.dotted_name import DottedName
@@ -19,13 +17,3 @@ class DottedNameAsName(PythonNode):
 
         self.dotted_name: DottedName = dotted_name
         self.name: Optional[Name] = name
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.dotted_name != other.dotted_name:
-            return False
-
-        if self.name != other.name:
-            return False
-
-        return True

--- a/arborista/nodes/python/dotted_name_as_names.py
+++ b/arborista/nodes/python/dotted_name_as_names.py
@@ -1,7 +1,5 @@
 """A Python dotted names as other names."""
-from typing import Any, Iterable, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Iterable, List, Optional
 
 from arborista.node import Node
 from arborista.nodes.python.dotted_name_as_name import DottedNameAsName
@@ -19,13 +17,3 @@ class DottedNameAsNames(PythonNode):
         self.first_dotted_name_as_name: DottedNameAsName = first_dotted_name_as_name
         self.rest_of_dotted_name_as_names: List[DottedNameAsName] = list(
             rest_of_dotted_name_as_names)
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first_dotted_name_as_name != other.first_dotted_name_as_name:
-            return False
-
-        if self.rest_of_dotted_name_as_names != other.rest_of_dotted_name_as_names:
-            return False
-
-        return True

--- a/arborista/nodes/python/double_quoted_long_string.py
+++ b/arborista/nodes/python/double_quoted_long_string.py
@@ -1,7 +1,5 @@
 """A double quoted long string."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.long_string import LongString
@@ -13,9 +11,3 @@ class DoubleQuotedLongString(LongString):
         super().__init__(parent)
 
         self.value: str = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-
-        return equality

--- a/arborista/nodes/python/double_quoted_short_string.py
+++ b/arborista/nodes/python/double_quoted_short_string.py
@@ -1,7 +1,5 @@
 """A double quoted short string."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.short_string import ShortString
@@ -13,9 +11,3 @@ class DoubleQuotedShortString(ShortString):
         super().__init__(parent)
 
         self.value: str = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-
-        return equality

--- a/arborista/nodes/python/ellipsis_node.py
+++ b/arborista/nodes/python/ellipsis_node.py
@@ -1,13 +1,7 @@
 """A Python ellipsis."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.atom import Atom
 
 
 class EllipsisNode(Atom):
     """A Python ellipsis."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/equals.py
+++ b/arborista/nodes/python/equals.py
@@ -1,13 +1,7 @@
 """A Python equals comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class Equals(ComparisonOperator):
     """A Python equals comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/expression_statement.py
+++ b/arborista/nodes/python/expression_statement.py
@@ -1,7 +1,5 @@
 """A Python expression statement."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.expression import Expression
@@ -14,8 +12,3 @@ class ExpressionStatement(SmallStatement):
         super().__init__(parent)
 
         self.expression: Expression = expression
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.expression == other.expression
-        return equality

--- a/arborista/nodes/python/float.py
+++ b/arborista/nodes/python/float.py
@@ -1,7 +1,5 @@
 """A Python float."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.number import Number
@@ -13,8 +11,3 @@ class Float(Number):
         super().__init__(parent)
 
         self.value: float = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/python/function_definition.py
+++ b/arborista/nodes/python/function_definition.py
@@ -1,7 +1,5 @@
 """A Python function defintion."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node, NodeIterator
 from arborista.nodes.python.compound_statement import CompoundStatement
@@ -22,19 +20,6 @@ class FunctionDefinition(CompoundStatement):
         self.name: Name = name
         self.parameters: ParameterList = list(parameters)
         self.body: Suite = body
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name != other.name:
-            return False
-
-        if self.parameters != other.parameters:
-            return False
-
-        if self.body != other.body:
-            return False
-
-        return True
 
     def iterate_children(self) -> NodeIterator:
         yield self.name

--- a/arborista/nodes/python/greater_than.py
+++ b/arborista/nodes/python/greater_than.py
@@ -1,13 +1,7 @@
 """A Python greater than comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class GreaterThan(ComparisonOperator):
     """A Python greater than comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/greater_than_or_equals.py
+++ b/arborista/nodes/python/greater_than_or_equals.py
@@ -1,13 +1,7 @@
 """A Python greater than or equals comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class GreaterThanOrEquals(ComparisonOperator):
     """A Python greater than or equals comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/grouped_name_as_names.py
+++ b/arborista/nodes/python/grouped_name_as_names.py
@@ -1,7 +1,5 @@
 """A group of names to be imported as other names."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.name_as_names import NameAsNames
@@ -14,10 +12,3 @@ class GroupedNameAsNames(PythonNode):
         super().__init__(parent)
 
         self.name_as_names: NameAsNames = name_as_names
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name_as_names != other.name_as_names:
-            return False
-
-        return True

--- a/arborista/nodes/python/imaginary.py
+++ b/arborista/nodes/python/imaginary.py
@@ -1,7 +1,5 @@
 """A Python imaginary."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.python.number import Number
@@ -13,8 +11,3 @@ class Imaginary(Number):
         super().__init__(parent)
 
         self.value: Union[int, float] = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/python/import_dotted_name.py
+++ b/arborista/nodes/python/import_dotted_name.py
@@ -1,7 +1,5 @@
 """A Python import dotted name statement."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.dotted_name_as_names import DottedNameAsNames
@@ -14,10 +12,3 @@ class ImportDottedName(ImportStatement):
         super().__init__(parent)
 
         self.dotted_name_as_names: DottedNameAsNames = dotted_name_as_names
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.dotted_name_as_names != other.dotted_name_as_names:
-            return False
-
-        return True

--- a/arborista/nodes/python/import_from.py
+++ b/arborista/nodes/python/import_from.py
@@ -1,7 +1,5 @@
 """A python import from statement."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.python.dotted_name import DottedName
@@ -22,13 +20,3 @@ class ImportFrom(ImportStatement):
 
         self.source: Source = source
         self.target: Target = target
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.source != other.source:
-            return False
-
-        if self.target != other.target:
-            return False
-
-        return True

--- a/arborista/nodes/python/in_.py
+++ b/arborista/nodes/python/in_.py
@@ -1,13 +1,7 @@
 """A Python in comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class In(ComparisonOperator):
     """A Python in comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/integer.py
+++ b/arborista/nodes/python/integer.py
@@ -1,7 +1,5 @@
 """A Python integer."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.number import Number
@@ -12,8 +10,3 @@ class Integer(Number):
     def __init__(self, value: int, parent: Optional[Node] = None):
         super().__init__(parent)
         self.value = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality

--- a/arborista/nodes/python/is_.py
+++ b/arborista/nodes/python/is_.py
@@ -1,13 +1,7 @@
 """A Python is comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class Is(ComparisonOperator):
     """A Python is comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/is_not.py
+++ b/arborista/nodes/python/is_not.py
@@ -1,13 +1,7 @@
 """A Python is not comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class IsNot(ComparisonOperator):
     """A Python is not comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/joined_string.py
+++ b/arborista/nodes/python/joined_string.py
@@ -1,7 +1,5 @@
 """A Python joined string."""
-from typing import Any, Iterable, Iterator, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Iterable, Iterator, List, Optional
 
 from arborista.node import Node
 from arborista.nodes.python.expression import Expression
@@ -14,13 +12,6 @@ class JoinedString(Expression):
         super().__init__(parent)
 
         self.strings: List[String] = list(strings)
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.strings != other.strings:
-            return False
-
-        return True
 
     def iterate_children(self) -> Iterator[String]:
         yield from self.strings

--- a/arborista/nodes/python/less_greater_than.py
+++ b/arborista/nodes/python/less_greater_than.py
@@ -1,13 +1,7 @@
 """A Python less greater than comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class LessGreaterThan(ComparisonOperator):
     """A Python less greater than comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/less_than.py
+++ b/arborista/nodes/python/less_than.py
@@ -1,13 +1,7 @@
 """A Python less than comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class LessThan(ComparisonOperator):
     """A Python less than comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/less_than_or_equals.py
+++ b/arborista/nodes/python/less_than_or_equals.py
@@ -1,13 +1,7 @@
 """A Python less than or equals comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class LessThanOrEquals(ComparisonOperator):
     """A Python less than or equals comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/module.py
+++ b/arborista/nodes/python/module.py
@@ -1,7 +1,5 @@
 """A Python module."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node, NodeIterator
 from arborista.nodes.python.python_node import PythonNode
@@ -23,16 +21,6 @@ class Module(PythonNode):
             self.statements = []
         else:
             self.statements = list(statements)
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name != other.name:
-            return False
-
-        if self.statements != other.statements:
-            return False
-
-        return True
 
     def iterate_children(self) -> NodeIterator:
         yield from self.statements

--- a/arborista/nodes/python/name.py
+++ b/arborista/nodes/python/name.py
@@ -1,7 +1,5 @@
 """A Python name."""
-from typing import Any, Iterable, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Iterable, Optional
 
 from arborista.node import Node
 from arborista.nodes.python.atom import Atom
@@ -13,11 +11,6 @@ class Name(Atom):
         super().__init__(parent)
 
         self.value: str = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-        return equality
 
 
 Names = Iterable[Name]

--- a/arborista/nodes/python/name_as_name.py
+++ b/arborista/nodes/python/name_as_name.py
@@ -1,7 +1,5 @@
 """A Python name to be imported as another name."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.name import Name
@@ -15,13 +13,3 @@ class NameAsName(PythonNode):
 
         self.name: Name = name
         self.new_name: Optional[Name] = new_name
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.name != other.name:
-            return False
-
-        if self.new_name != other.new_name:
-            return False
-
-        return True

--- a/arborista/nodes/python/name_as_names.py
+++ b/arborista/nodes/python/name_as_names.py
@@ -1,7 +1,5 @@
 """Python names to be imported as other names."""
-from typing import Any, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import List, Optional
 
 from arborista.node import Node
 from arborista.nodes.python.name_as_name import NameAsName
@@ -15,13 +13,3 @@ class NameAsNames(PythonNode):
 
         self.first: NameAsName = first
         self.rest: List[NameAsName] = rest
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.first != other.first:
-            return False
-
-        if self.rest != other.rest:
-            return False
-
-        return True

--- a/arborista/nodes/python/not_equals.py
+++ b/arborista/nodes/python/not_equals.py
@@ -1,13 +1,7 @@
 """A Python not equals comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class NotEquals(ComparisonOperator):
     """A Python not equals comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/not_in.py
+++ b/arborista/nodes/python/not_in.py
@@ -1,13 +1,7 @@
 """A Python not in comparison operator."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 
 
 class NotIn(ComparisonOperator):
     """A Python not in comparison operator."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/or_.py
+++ b/arborista/nodes/python/or_.py
@@ -1,5 +1,5 @@
 """A Python or operator."""
-from typing import Any, Optional
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.boolean_operator import BooleanOperator
@@ -9,6 +9,3 @@ class Or(BooleanOperator):
     """A Python or operator."""
     def __init__(self, parent: Optional[Node] = None):
         super().__init__(parent)
-
-    def __eq__(self, other: Any) -> bool:
-        return isinstance(other, Or)

--- a/arborista/nodes/python/parameter.py
+++ b/arborista/nodes/python/parameter.py
@@ -1,7 +1,5 @@
 """A Python parameter."""
-from typing import Any, Iterable, List, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Iterable, List, Optional
 
 from arborista.node import Node, NodeIterator
 from arborista.nodes.python.name import Name
@@ -14,11 +12,6 @@ class Parameter(PythonNode):
         super().__init__(parent)
 
         self.name: Name = name
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.name == other.name
-        return equality
 
     def iterate_children(self) -> NodeIterator:
         yield self.name

--- a/arborista/nodes/python/pass_statement.py
+++ b/arborista/nodes/python/pass_statement.py
@@ -1,13 +1,7 @@
 """A Python pass statement."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.small_statement import SmallStatement
 
 
 class PassStatement(SmallStatement):
     """A Python pass statement."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/python_node.py
+++ b/arborista/nodes/python/python_node.py
@@ -1,6 +1,17 @@
 """A Python node."""
+from abc import ABC
+from typing import Any
+
+from seligimus.python.decorators.operators.equality.equal_instance_attributes import \
+    equal_instance_attributes
+from seligimus.python.decorators.operators.equality.equal_type import equal_type
+
 from arborista.node import Node
 
 
-class PythonNode(Node):
+class PythonNode(Node, ABC):
     """A Python node."""
+    @equal_type
+    @equal_instance_attributes(excludes={'parent'})
+    def __eq__(self, other: Any) -> bool:
+        return True

--- a/arborista/nodes/python/relative_dotted_name.py
+++ b/arborista/nodes/python/relative_dotted_name.py
@@ -1,7 +1,5 @@
 """A relative dotted name."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.dotted_name import DottedName
@@ -15,13 +13,3 @@ class RelativeDottedName(PythonNode):
 
         self.dots: int = dots
         self.dotted_name: Optional[DottedName] = dotted_name
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.dots != other.dots:
-            return False
-
-        if self.dotted_name != other.dotted_name:
-            return False
-
-        return True

--- a/arborista/nodes/python/return_statement.py
+++ b/arborista/nodes/python/return_statement.py
@@ -1,13 +1,7 @@
 """A Python return statement."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from arborista.nodes.python.flow_statement import FlowStatement
 
 
 class ReturnStatement(FlowStatement):
     """A Python return statement."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/simple_statement.py
+++ b/arborista/nodes/python/simple_statement.py
@@ -1,7 +1,5 @@
 """A Python simple statement."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node, NodeIterator
 from arborista.nodes.python.small_statement import SmallStatementList, SmallStatements
@@ -14,13 +12,6 @@ class SimpleStatement(Statement):
         super().__init__(parent)
 
         self.small_statements: SmallStatementList = list(small_statements)
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if len(self.small_statements) != len(other.small_statements):
-            return False
-        return all(small_statement == other_small_statement for small_statement,
-                   other_small_statement in zip(self.small_statements, other.small_statements))
 
     def iterate_children(self) -> NodeIterator:
         yield from self.small_statements

--- a/arborista/nodes/python/single_quoted_long_string.py
+++ b/arborista/nodes/python/single_quoted_long_string.py
@@ -1,7 +1,5 @@
 """A single quoted long string."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.long_string import LongString
@@ -13,9 +11,3 @@ class SingleQuotedLongString(LongString):
         super().__init__(parent)
 
         self.value: str = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-
-        return equality

--- a/arborista/nodes/python/single_quoted_short_string.py
+++ b/arborista/nodes/python/single_quoted_short_string.py
@@ -1,7 +1,5 @@
 """A single quoted short string."""
-from typing import Any, Optional
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional
 
 from arborista.node import Node
 from arborista.nodes.python.short_string import ShortString
@@ -13,9 +11,3 @@ class SingleQuotedShortString(ShortString):
         super().__init__(parent)
 
         self.value: str = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-
-        return equality

--- a/arborista/nodes/python/star.py
+++ b/arborista/nodes/python/star.py
@@ -1,12 +1,5 @@
 """A Python star import target."""
-from typing import Any
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from arborista.nodes.python.python_node import PythonNode
-
 
 class Star(PythonNode):
     """A Python star import target."""
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        return True

--- a/arborista/nodes/python/star.py
+++ b/arborista/nodes/python/star.py
@@ -1,5 +1,6 @@
 """A Python star import target."""
 from arborista.nodes.python.python_node import PythonNode
 
+
 class Star(PythonNode):
     """A Python star import target."""

--- a/arborista/nodes/python/string.py
+++ b/arborista/nodes/python/string.py
@@ -1,7 +1,5 @@
 """A Python string."""
-from typing import Any, Optional, Union
-
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
+from typing import Optional, Union
 
 from arborista.node import Node
 from arborista.nodes.python.atom import Atom
@@ -22,13 +20,3 @@ class String(Atom):
 
         self.prefix: Optional[StringPrefix] = prefix
         self.value: StringValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        if self.prefix != other.prefix:
-            return False
-
-        if self.value != other.value:
-            return False
-
-        return True

--- a/arborista/nodes/python/string_prefix.py
+++ b/arborista/nodes/python/string_prefix.py
@@ -1,7 +1,6 @@
 """A string prefix."""
-from typing import Any, Optional
+from typing import Optional
 
-from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from typing_extensions import Literal
 
 from arborista.node import Node
@@ -17,9 +16,3 @@ class StringPrefix(PythonNode):
         super().__init__(parent)
 
         self.value: StringPrefixValue = value
-
-    @equal_type
-    def __eq__(self, other: Any) -> bool:
-        equality: bool = self.value == other.value
-
-        return equality

--- a/requirements/frozen/frozen_developer_requirements.txt
+++ b/requirements/frozen/frozen_developer_requirements.txt
@@ -1,6 +1,6 @@
 isort==5.8.0
 mypy==0.812
 mypy-extensions==0.4.3
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 yapf==0.31.0

--- a/requirements/frozen/frozen_test_requirements.txt
+++ b/requirements/frozen/frozen_test_requirements.txt
@@ -1,8 +1,8 @@
-astroid==2.5.2
+astroid==2.5.3
 attrs==20.3.0
 coverage==5.5
 dataclasses==0.8
-importlib-metadata==3.10.0
+importlib-metadata==3.10.1
 iniconfig==1.1.1
 isort==5.8.0
 lazy-object-proxy==1.6.0
@@ -18,9 +18,9 @@ pyparsing==2.4.7
 pytest==6.2.2
 pytest-cov==2.11.1
 PyYAML==5.4.1
-seligimus==0.12.0
+seligimus==0.13.0
 toml==0.10.2
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 typing-inspect==0.6.0
 wrapt==1.12.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
 libcst==0.3.18
-seligimus==0.12.0
+seligimus==0.13.0

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -3,4 +3,4 @@ mypy==0.812
 pylint==2.7.4
 pytest==6.2.2
 pytest-cov==2.11.1
-seligimus==0.12.0
+seligimus==0.13.0

--- a/tests/nodes/nebnf/test_alternation.py
+++ b/tests/nodes/nebnf/test_alternation.py
@@ -37,20 +37,3 @@ def test_init(first_choice: RighthandSide, second_choice: RighthandSide, parent:
     assert alternation.first_choice == first_choice
     assert alternation.second_choice == second_choice
     assert alternation.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('alternation, other, expected_equality', [
-    (Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), 1, False),
-    (Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), 'F', False),
-    (Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Alternation(RighthandSide(Identifier(UppercaseLetter('S'), [])), RighthandSide(Identifier(UppercaseLetter('E'), []))), False),
-    (Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('E'), []))), False),
-    (Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Alternation(RighthandSide(Identifier(UppercaseLetter('S'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), False),
-    (Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Alternation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(alternation: Alternation, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.alternation.Alternation.__eq__."""
-    equality: bool = alternation == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_character.py
+++ b/tests/nodes/nebnf/test_character.py
@@ -46,18 +46,3 @@ def test_init(value: CharacterValue, parent: Optional[Node], pass_parent: bool) 
 
     assert character.value == value
     assert character.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('character, other, expected_equality', [
-    (Character('a'), 1, False),
-    (Character('a'), 'a', False),
-    (Character('a'), Character('b'), False),
-    (Character('a'), Character('a'), True),
-])
-# yapf: enable
-def test_eq(character: Character, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.character.Character.__eq__."""
-    equality: bool = character == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_concatenation.py
+++ b/tests/nodes/nebnf/test_concatenation.py
@@ -37,20 +37,3 @@ def test_init(first: RighthandSide, second: RighthandSide, parent: Optional[Node
     assert concatenation.first == first
     assert concatenation.second == second
     assert concatenation.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('concatenation, other, expected_equality', [
-    (Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), 1, False),
-    (Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), 'F', False),
-    (Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Concatenation(RighthandSide(Identifier(UppercaseLetter('S'), [])), RighthandSide(Identifier(UppercaseLetter('E'), []))), False),
-    (Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('E'), []))), False),
-    (Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Concatenation(RighthandSide(Identifier(UppercaseLetter('S'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), False),
-    (Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Concatenation(RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(concatenation: Concatenation, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.concatenation.Concatenation.__eq__."""
-    equality: bool = concatenation == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_digit.py
+++ b/tests/nodes/nebnf/test_digit.py
@@ -40,18 +40,3 @@ def test_init(value: DigitValue, parent: Optional[Node], pass_parent: bool) -> N
 
     assert digit.value == value
     assert digit.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('digit, other, expected_equality', [
-    (Digit('0'), 0, False),
-    (Digit('0'), '0', False),
-    (Digit('0'), Digit('1'), False),
-    (Digit('0'), Digit('0'), True),
-])
-# yapf: enable
-def test_eq(digit: Digit, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.digit.Digit.__eq__."""
-    equality: bool = digit == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_double_quoted_terminal.py
+++ b/tests/nodes/nebnf/test_double_quoted_terminal.py
@@ -36,20 +36,3 @@ def test_init(first_character: Character, rest_of_characters: List[Character],
     assert double_quoted_terminal.first_character == first_character
     assert double_quoted_terminal.rest_of_characters == rest_of_characters
     assert double_quoted_terminal.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('double_quoted_terminal, other, expected_equality', [
-    (DoubleQuotedTerminal(Character('f'), []), 'f', False),
-    (DoubleQuotedTerminal(Character('f'), []), DoubleQuotedTerminal(Character('b'), []), False),
-    (DoubleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), DoubleQuotedTerminal(Character('f'), []), False),
-    (DoubleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), DoubleQuotedTerminal(Character('b'), [Character('o'), Character('o')]), False),
-    (DoubleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), DoubleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(double_quoted_terminal: DoubleQuotedTerminal, other: Any,
-            expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.double_quoted_terminal.DoubleQuotedTerminal.__eq__."""
-    equality: bool = double_quoted_terminal == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_grammer.py
+++ b/tests/nodes/nebnf/test_grammer.py
@@ -37,17 +37,3 @@ def test_init(rules: List[Rule], parent: Optional[Node], pass_parent: bool) -> N
 
     assert grammer.rules == rules
     assert grammer.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('grammer, other, expected_equality', [
-    (Grammer([]), 'f', False),
-    (Grammer([Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), [])))]), Grammer([]), False),
-    (Grammer([Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), [])))]), Grammer([Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), [])))]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(grammer: Grammer, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.grammer.Grammer.__eq__."""
-    equality: bool = grammer == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_grouping.py
+++ b/tests/nodes/nebnf/test_grouping.py
@@ -43,19 +43,3 @@ def test_init(name: Optional[Name], righthand_side: RighthandSide, parent: Optio
     assert grouping.name == name
     assert grouping.righthand_side == righthand_side
     assert grouping.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('grouping, other, expected_equality', [
-    (Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), 1, False),
-    (Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), 'F', False),
-    (Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Grouping(Name(LowercaseLetter('m'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), False),
-    (Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('B'), []))), False),
-    (Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Grouping(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(grouping: Grouping, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.grouping.Grouping.__eq__."""
-    equality: bool = grouping == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_identifier.py
+++ b/tests/nodes/nebnf/test_identifier.py
@@ -38,19 +38,3 @@ def test_init(first_character: UppercaseLetter,
     assert identifier.first_character == first_character
     assert identifier.rest_of_characters == rest_of_characters
     assert identifier.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('identifier, other, expected_equality', [
-    (Identifier(UppercaseLetter('F'), []), 'F', False),
-    (Identifier(UppercaseLetter('F'), []), Identifier(UppercaseLetter('B'), []), False),
-    (Identifier(UppercaseLetter('F'), [LowercaseLetter('o'), LowercaseLetter('o')]), Identifier(UppercaseLetter('F'), []), False),
-    (Identifier(UppercaseLetter('F'), [LowercaseLetter('o'), LowercaseLetter('o')]), Identifier(UppercaseLetter('B'), [LowercaseLetter('o'), LowercaseLetter('o')]), False),
-    (Identifier(UppercaseLetter('F'), [LowercaseLetter('o'), LowercaseLetter('o')]), Identifier(UppercaseLetter('F'), [LowercaseLetter('o'), LowercaseLetter('o')]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(identifier: Identifier, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.identifier.Identifier.__eq__."""
-    equality: bool = identifier == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_lefthand_side.py
+++ b/tests/nodes/nebnf/test_lefthand_side.py
@@ -33,18 +33,3 @@ def test_init(identifier: Identifier, parent: Optional[Node], pass_parent: bool)
 
     assert lefthand_side.identifier == identifier
     assert lefthand_side.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('lefthand_side, other, expected_equality', [
-    (LefthandSide(Identifier(UppercaseLetter('F'), [])), 1, False),
-    (LefthandSide(Identifier(UppercaseLetter('F'), [])), 'F', False),
-    (LefthandSide(Identifier(UppercaseLetter('F'), [])), LefthandSide(Identifier(UppercaseLetter('B'), [])), False),
-    (LefthandSide(Identifier(UppercaseLetter('F'), [])), LefthandSide(Identifier(UppercaseLetter('F'), [])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(lefthand_side: LefthandSide, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.lefthand_side.LefthandSide.__eq__."""
-    equality: bool = lefthand_side == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_letter.py
+++ b/tests/nodes/nebnf/test_letter.py
@@ -43,18 +43,3 @@ def test_init(value: LetterValue, parent: Optional[Node], pass_parent: bool) -> 
 
     assert letter.value == value
     assert letter.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('letter, other, expected_equality', [
-    (Letter('a'), 1, False),
-    (Letter('a'), 'a', False),
-    (Letter('a'), Letter('b'), False),
-    (Letter('a'), Letter('a'), True),
-])
-# yapf: enable
-def test_eq(letter: Letter, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.letter.Letter.__eq__."""
-    equality: bool = letter == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_lowercase_letter.py
+++ b/tests/nodes/nebnf/test_lowercase_letter.py
@@ -41,18 +41,3 @@ def test_init(value: LowercaseLetterValue, parent: Optional[Node], pass_parent: 
 
     assert lowercase_letter.value == value
     assert lowercase_letter.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('lowercase_letter, other, expected_equality', [
-    (LowercaseLetter('a'), 1, False),
-    (LowercaseLetter('a'), 'a', False),
-    (LowercaseLetter('a'), LowercaseLetter('b'), False),
-    (LowercaseLetter('a'), LowercaseLetter('a'), True),
-])
-# yapf: enable
-def test_eq(lowercase_letter: LowercaseLetter, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.lowercase_letter.LowercaseLetter.__eq__."""
-    equality: bool = lowercase_letter == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_name.py
+++ b/tests/nodes/nebnf/test_name.py
@@ -38,19 +38,3 @@ def test_init(first_character: LowercaseLetter, rest_of_characters: List[Union[L
     assert name.first_character == first_character
     assert name.rest_of_characters == rest_of_characters
     assert name.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('name, other, expected_equality', [
-    (Name(LowercaseLetter('f'), []), 'f', False),
-    (Name(LowercaseLetter('f'), []), Name(LowercaseLetter('b'), []), False),
-    (Name(LowercaseLetter('f'), [LowercaseLetter('o'), LowercaseLetter('o')]), Name(LowercaseLetter('f'), []), False),
-    (Name(LowercaseLetter('f'), [LowercaseLetter('o'), LowercaseLetter('o')]), Name(LowercaseLetter('b'), [LowercaseLetter('o'), LowercaseLetter('o')]), False),
-    (Name(LowercaseLetter('f'), [LowercaseLetter('o'), LowercaseLetter('o')]), Name(LowercaseLetter('f'), [LowercaseLetter('o'), LowercaseLetter('o')]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(name: Name, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.name.Name.__eq__."""
-    equality: bool = name == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_nebnf_node.py
+++ b/tests/nodes/nebnf/test_nebnf_node.py
@@ -1,5 +1,9 @@
 """Test arborista.nodes.nebnf.nebnf_node."""
 from abc import ABC
+from typing import Any, Dict
+
+import pytest
+from seligimus.python.classes.attributes import set_attributes
 
 from arborista.node import Node
 from arborista.nodes.nebnf.nebnf_node import NEBNFNode
@@ -8,3 +12,31 @@ from arborista.nodes.nebnf.nebnf_node import NEBNFNode
 def test_inheritance() -> None:
     """Test arborista.nodes.nebnf.nebnf_node.NEBNFNode inheritance."""
     assert issubclass(NEBNFNode, (Node, ABC))
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('self_class_name, other_class_name, self_attributes, other_attributes, expected_equality', [
+    ('Foo', 'Bar', {'parent': 1}, {'parent': 1}, False),
+    ('Foo', 'Foo', {'parent': 1, 'wibble': 2}, {'parent': 1, 'wibble': 3}, False),
+    ('Foo', 'Foo', {'parent': 1}, {'parent': 2}, True),
+    ('Foo', 'Foo', {'parent': 1, 'wibble': 2}, {'parent': 1, 'wibble': 2}, True),
+    ('Foo', 'Foo', {'parent': 1, 'wibble': 2}, {'parent': 2, 'wibble': 2}, True),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_eq(self_class_name: str, other_class_name: str, self_attributes: Dict[str, Any],
+            other_attributes: Dict[str, Any], expected_equality: bool) -> None:
+    """Test arborista.nodes.nebnf.nebnf_node.NEBNFNode.__eq__."""
+    self_type = type(self_class_name, tuple(), {})
+    self = self_type()
+    set_attributes(self, self_attributes)
+
+    if other_class_name == self_class_name:
+        other_type = self_type
+    else:
+        other_type = type(other_class_name, tuple(), {})
+    other = other_type()
+    set_attributes(other, other_attributes)
+
+    equality: bool = NEBNFNode.__eq__(self, other)
+
+    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_option.py
+++ b/tests/nodes/nebnf/test_option.py
@@ -43,19 +43,3 @@ def test_init(name: Optional[Name], righthand_side: RighthandSide, parent: Optio
     assert option.name == name
     assert option.righthand_side == righthand_side
     assert option.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('option, other, expected_equality', [
-    (Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), 1, False),
-    (Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), 'F', False),
-    (Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('B'), []))), False),
-    (Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Option(Name(LowercaseLetter('m'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), False),
-    (Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Option(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(option: Option, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.option.Option.__eq__."""
-    equality: bool = option == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_repetition.py
+++ b/tests/nodes/nebnf/test_repetition.py
@@ -43,19 +43,3 @@ def test_init(name: Optional[Name], element: RighthandSide, parent: Optional[Nod
     assert repetition.name == name
     assert repetition.element == element
     assert repetition.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('repetition, other, expected_equality', [
-    (Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), 1, False),
-    (Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), 'F', False),
-    (Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('B'), []))), False),
-    (Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Repetition(Name(LowercaseLetter('m'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), False),
-    (Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), Repetition(Name(LowercaseLetter('n'), []), RighthandSide(Identifier(UppercaseLetter('F'), []))), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(repetition: Repetition, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.repetition.Repetition.__eq__."""
-    equality: bool = repetition == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_righthand_side.py
+++ b/tests/nodes/nebnf/test_righthand_side.py
@@ -49,18 +49,3 @@ def test_init(expression: Expression, parent: Optional[Node], pass_parent: bool)
 
     assert righthand_side.expression == expression
     assert righthand_side.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('righthand_side, other, expected_equality', [
-    (RighthandSide(Identifier(UppercaseLetter('F'), [])), 1, False),
-    (RighthandSide(Identifier(UppercaseLetter('F'), [])), 'F', False),
-    (RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), [])), False),
-    (RighthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('F'), [])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(righthand_side: RighthandSide, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.righthand_side.RighthandSide.__eq__."""
-    equality: bool = righthand_side == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_rule.py
+++ b/tests/nodes/nebnf/test_rule.py
@@ -38,20 +38,3 @@ def test_init(lefthand_side: LefthandSide, righthand_side: RighthandSide, parent
     assert rule.lefthand_side == lefthand_side
     assert rule.righthand_side == righthand_side
     assert rule.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('rule, other, expected_equality', [
-    (Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), 1, False),
-    (Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), 'F', False),
-    (Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Rule(LefthandSide(Identifier(UppercaseLetter('S'), [])), RighthandSide(Identifier(UppercaseLetter('E'), []))), False),
-    (Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('E'), []))), False),
-    (Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Rule(LefthandSide(Identifier(UppercaseLetter('S'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), False),
-    (Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), Rule(LefthandSide(Identifier(UppercaseLetter('F'), [])), RighthandSide(Identifier(UppercaseLetter('B'), []))), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(rule: Rule, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.rule.Rule.__eq__."""
-    equality: bool = rule == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_single_quoted_terminal.py
+++ b/tests/nodes/nebnf/test_single_quoted_terminal.py
@@ -36,20 +36,3 @@ def test_init(first_character: Character, rest_of_characters: List[Character],
     assert single_quoted_terminal.first_character == first_character
     assert single_quoted_terminal.rest_of_characters == rest_of_characters
     assert single_quoted_terminal.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('single_quoted_terminal, other, expected_equality', [
-    (SingleQuotedTerminal(Character('f'), []), 'f', False),
-    (SingleQuotedTerminal(Character('f'), []), SingleQuotedTerminal(Character('b'), []), False),
-    (SingleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), SingleQuotedTerminal(Character('f'), []), False),
-    (SingleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), SingleQuotedTerminal(Character('b'), [Character('o'), Character('o')]), False),
-    (SingleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), SingleQuotedTerminal(Character('f'), [Character('o'), Character('o')]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(single_quoted_terminal: SingleQuotedTerminal, other: Any,
-            expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.single_quoted_terminal.SingleQuotedTerminal.__eq__."""
-    equality: bool = single_quoted_terminal == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_symbol.py
+++ b/tests/nodes/nebnf/test_symbol.py
@@ -39,18 +39,3 @@ def test_init(value: SymbolValue, parent: Optional[Node], pass_parent: bool) -> 
 
     assert symbol.value == value
     assert symbol.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('lowercase_symbol, other, expected_equality', [
-    (Symbol('['), 1, False),
-    (Symbol('['), '[', False),
-    (Symbol('['), Symbol(']'), False),
-    (Symbol('['), Symbol('['), True),
-])
-# yapf: enable
-def test_eq(lowercase_symbol: Symbol, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.symbol.Symbol.__eq__."""
-    equality: bool = lowercase_symbol == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_terminal.py
+++ b/tests/nodes/nebnf/test_terminal.py
@@ -45,18 +45,3 @@ def test_init(value: TerminalValue, parent: Optional[Node], pass_parent: bool) -
 
     assert terminal.value == value
     assert terminal.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('terminal, other, expected_equality', [
-    (Terminal(SingleQuotedTerminal(Character('a'), [])), 1, False),
-    (Terminal(SingleQuotedTerminal(Character('a'), [])), Character('a'), False),
-    (Terminal(SingleQuotedTerminal(Character('a'), [])), Terminal(SingleQuotedTerminal(Character('b'), [])), False),
-    (Terminal(SingleQuotedTerminal(Character('a'), [])), Terminal(SingleQuotedTerminal(Character('a'), [])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(terminal: Terminal, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.terminal.Terminal.__eq__."""
-    equality: bool = terminal == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_underscore.py
+++ b/tests/nodes/nebnf/test_underscore.py
@@ -39,17 +39,3 @@ def test_init(parent: Optional[Node], pass_parent: bool) -> None:
 
     assert underscore.value == '_'
     assert underscore.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('underscore, other, expected_equality', [
-    (Underscore(), 1, False),
-    (Underscore(), '_', False),
-    (Underscore(), Underscore(), True),
-])
-# yapf: enable
-def test_eq(underscore: Underscore, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.underscore.Underscore.__eq__."""
-    equality: bool = underscore == other
-
-    assert equality == expected_equality

--- a/tests/nodes/nebnf/test_uppercase_letter.py
+++ b/tests/nodes/nebnf/test_uppercase_letter.py
@@ -41,18 +41,3 @@ def test_init(value: UppercaseLetterValue, parent: Optional[Node], pass_parent: 
 
     assert uppercase_letter.value == value
     assert uppercase_letter.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('uppercase_letter, other, expected_equality', [
-    (UppercaseLetter('A'), 1, False),
-    (UppercaseLetter('A'), 'A', False),
-    (UppercaseLetter('A'), UppercaseLetter('B'), False),
-    (UppercaseLetter('A'), UppercaseLetter('A'), True),
-])
-# yapf: enable
-def test_eq(uppercase_letter: UppercaseLetter, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.nebnf.uppercase_letter.UppercaseLetter.__eq__."""
-    equality: bool = uppercase_letter == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_and.py
+++ b/tests/nodes/python/test_and.py
@@ -1,5 +1,5 @@
 """Test arborista.nodes.python.and_."""
-from typing import Any, Optional
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,16 +28,3 @@ def test_init(parent: Optional[Expression], pass_parent: bool) -> None:
     and_: And = And(**keyword_arguments)
 
     assert and_.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('and_, other, expected_equality', [
-    (And(), 'foo', False),
-    (And(), And(), True),
-])
-# yapf: enable
-def test_eq(and_: And, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.and_.And.__eq__."""
-    equality: bool = and_ == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_block.py
+++ b/tests/nodes/python/test_block.py
@@ -61,20 +61,6 @@ def test_init(body: Statements, expected_body: StatementList, indent: str, paren
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('block, other, expected_equality', [
-    (Block([SimpleStatement([ReturnStatement()])], '   '), 'foo', False),
-    (Block([SimpleStatement([ReturnStatement()])], '   '), Block([SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])], '   '), False),
-    (Block([SimpleStatement([ReturnStatement()])], '   '), Block([SimpleStatement([ReturnStatement()])], '   '), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(block: Block, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.block.Block.__eq__."""
-    equality: bool = block == other
-
-    assert equality == expected_equality
-
-
-# yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('block, expected_children_list', [
     (Block([SimpleStatement([ReturnStatement()])], '   '), [SimpleStatement([ReturnStatement()])]),
     (Block([SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])], '   '), [SimpleStatement([ReturnStatement()]), SimpleStatement([ReturnStatement()])]),

--- a/tests/nodes/python/test_boolean_operation.py
+++ b/tests/nodes/python/test_boolean_operation.py
@@ -10,7 +10,6 @@ from arborista.nodes.python.boolean_operation import BooleanOperation
 from arborista.nodes.python.boolean_operator import BooleanOperator
 from arborista.nodes.python.expression import Expression
 from arborista.nodes.python.name import Name
-from arborista.nodes.python.or_ import Or
 
 
 def test_inheritance() -> None:
@@ -39,22 +38,6 @@ def test_init(left: Expression, operator: BooleanOperator, right: Expression,
     assert boolean_operation.operator == operator
     assert boolean_operation.right == right
     assert boolean_operation.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('boolean_operation, other, expected_equality', [
-    (BooleanOperation(Name('a'), And(), Name('b')), 'foo', False),
-    (BooleanOperation(Name('a'), And(), Name('b')), BooleanOperation(Name('b'), And(), Name('b')), False),
-    (BooleanOperation(Name('a'), And(), Name('b')), BooleanOperation(Name('a'), Or(), Name('b')), False),
-    (BooleanOperation(Name('a'), And(), Name('b')), BooleanOperation(Name('a'), And(), Name('a')), False),
-    (BooleanOperation(Name('a'), And(), Name('b')), BooleanOperation(Name('a'), And(), Name('b')), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(boolean_operation: BooleanOperation, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.boolean_operation.BooleanOperation.__eq__."""
-    equality: bool = boolean_operation == other
-
-    assert equality == expected_equality
 
 
 # yapf: disable

--- a/tests/nodes/python/test_break_statement.py
+++ b/tests/nodes/python/test_break_statement.py
@@ -1,8 +1,4 @@
 """Test arborista.nodes.python.break_statement."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.break_statement import BreakStatement
 from arborista.nodes.python.flow_statement import FlowStatement
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.flow_statement import FlowStatement
 def test_inheritance() -> None:
     """Test arborista.nodes.python.break_statement.BreakStatement inheritance."""
     assert issubclass(BreakStatement, FlowStatement)
-
-
-# yapf: disable
-@pytest.mark.parametrize('break_statement, other, expected_equality', [
-    (BreakStatement(), 'foo', False),
-    (BreakStatement(), BreakStatement(), True),
-])
-# yapf: enable
-def test_eq(break_statement: BreakStatement, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.break_statement.BreakStatement.__eq__."""
-    equality: bool = break_statement == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_comparison.py
+++ b/tests/nodes/python/test_comparison.py
@@ -8,7 +8,6 @@ from arborista.node import Node
 from arborista.nodes.python.comparison import Comparison
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.expression import Expression
-from arborista.nodes.python.greater_than import GreaterThan
 from arborista.nodes.python.integer import Integer
 from arborista.nodes.python.less_than import LessThan
 
@@ -38,19 +37,3 @@ def test_init(left: Expression, comparison_operator: ComparisonOperator, right: 
     assert comparison.comparison_operator == comparison_operator
     assert comparison.right == right
     assert comparison.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('comparison, other, expected_equality', [
-    (Comparison(Integer(1), LessThan(), Integer(2)), 'foo', False),
-    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(1), LessThan(), Integer(3)), False),
-    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(1), GreaterThan(), Integer(2)), False),
-    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(2), LessThan(), Integer(2)), False),
-    (Comparison(Integer(1), LessThan(), Integer(2)), Comparison(Integer(1), LessThan(), Integer(2)), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(comparison: Comparison, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.comparison.Comparison.__eq__."""
-    equality: bool = comparison == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_continue_statement.py
+++ b/tests/nodes/python/test_continue_statement.py
@@ -1,8 +1,4 @@
 """Test arborista.nodes.python.continue_statement."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.continue_statement import ContinueStatement
 from arborista.nodes.python.flow_statement import FlowStatement
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.flow_statement import FlowStatement
 def test_inheritance() -> None:
     """Test arborista.nodes.python.continue_statement.ContinueStatement inheritance."""
     assert issubclass(ContinueStatement, FlowStatement)
-
-
-# yapf: disable
-@pytest.mark.parametrize('continue_statement, other, expected_equality', [
-    (ContinueStatement(), 'foo', False),
-    (ContinueStatement(), ContinueStatement(), True),
-])
-# yapf: enable
-def test_eq(continue_statement: ContinueStatement, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.continue_statement.ContinueStatement.__eq__."""
-    equality: bool = continue_statement == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_dotted_name.py
+++ b/tests/nodes/python/test_dotted_name.py
@@ -37,17 +37,3 @@ def test_init(first_name: Name, rest_of_names: Names, parent: Optional[Node],
     assert dotted_name.first_name == first_name
     assert dotted_name.rest_of_names == rest_of_names
     assert dotted_name.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('dotted_name, other, expected_equality', [
-    (DottedName(Name('foo'), []), 'foo', False),
-    (DottedName(Name('foo'), []), DottedName(Name('foo'), [Name('bar')]), False),
-    (DottedName(Name('foo'), [Name('bar')]), DottedName(Name('foo'), [Name('bar')]), True),
-])
-# yapf: enable
-def test_eq(dotted_name: DottedName, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.dotted_name.DottedName.__eq__."""
-    equality: bool = dotted_name == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_dotted_name_as_name.py
+++ b/tests/nodes/python/test_dotted_name_as_name.py
@@ -40,18 +40,3 @@ def test_init(dotted_name: DottedName, name: Optional[Name], parent: Optional[No
     assert dotted_name_as_name.dotted_name == dotted_name
     assert dotted_name_as_name.name == name
     assert dotted_name_as_name.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('dotted_name_as_name, other, expected_equality', [
-    (DottedNameAsName(DottedName(Name('foo'), [])), 'foo', False),
-    (DottedNameAsName(DottedName(Name('foo'), [])), DottedNameAsName(DottedName(Name('foo'), []), Name('bar')), False),
-    (DottedNameAsName(DottedName(Name('fooey'), []), Name('bar')), DottedNameAsName(DottedName(Name('foo'), []), Name('bar')), False),
-    (DottedNameAsName(DottedName(Name('foo'), []), Name('bar')), DottedNameAsName(DottedName(Name('foo'), []), Name('bar')), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(dotted_name_as_name: DottedNameAsName, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.dotted_name_as_name.DottedNameAsName.__eq__."""
-    equality: bool = dotted_name_as_name == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_dotted_name_as_names.py
+++ b/tests/nodes/python/test_dotted_name_as_names.py
@@ -40,18 +40,3 @@ def test_init(first_dotted_name_as_name: DottedNameAsName,
     assert dotted_name_as_names.first_dotted_name_as_name == first_dotted_name_as_name
     assert dotted_name_as_names.rest_of_dotted_name_as_names == rest_of_dotted_name_as_names
     assert dotted_name_as_names.parent == parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('dotted_name_as_names, other, expected_equality', [
-    (DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), []), 'foo', False),
-    (DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), []), DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [DottedNameAsName(DottedName(Name('bar'), []))]), False),
-    (DottedNameAsNames(DottedNameAsName(DottedName(Name('fooey'), [])), [DottedNameAsName(DottedName(Name('bar'), []))]), DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [DottedNameAsName(DottedName(Name('bar'), []))]), False),
-    (DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [DottedNameAsName(DottedName(Name('bar'), []))]), DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [DottedNameAsName(DottedName(Name('bar'), []))]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(dotted_name_as_names: DottedNameAsNames, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.dotted_name_as_names.DottedNameAsNames.__eq__."""
-    equality: bool = dotted_name_as_names == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_double_quoted_long_string.py
+++ b/tests/nodes/python/test_double_quoted_long_string.py
@@ -32,18 +32,3 @@ def test_init(value: str, parent: Optional[Node], pass_parent: bool) -> None:
 
     assert single_quoted_long_string.value == value
     assert single_quoted_long_string.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('single_quoted_long_string, other, expected_equality', [
-    (SingleQuotedLongString('foo'), 'foo', False),
-    (SingleQuotedLongString('foo'), SingleQuotedLongString('bar'), False),
-    (SingleQuotedLongString('foo'), SingleQuotedLongString('foo'), True),
-])
-# yapf: enable
-def test_eq(single_quoted_long_string: SingleQuotedLongString, other: Any,
-            expected_equality: bool) -> None:
-    """Test arborista.nodes.python.single_quoted_long_string.SingleQuotedLongString.__eq__."""
-    equality: bool = single_quoted_long_string == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_double_quoted_short_string.py
+++ b/tests/nodes/python/test_double_quoted_short_string.py
@@ -32,18 +32,3 @@ def test_init(value: str, parent: Optional[Node], pass_parent: bool) -> None:
 
     assert single_quoted_short_string.value == value
     assert single_quoted_short_string.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('single_quoted_short_string, other, expected_equality', [
-    (SingleQuotedShortString('foo'), 'foo', False),
-    (SingleQuotedShortString('foo'), SingleQuotedShortString('bar'), False),
-    (SingleQuotedShortString('foo'), SingleQuotedShortString('foo'), True),
-])
-# yapf: enable
-def test_eq(single_quoted_short_string: SingleQuotedShortString, other: Any,
-            expected_equality: bool) -> None:
-    """Test arborista.nodes.python.single_quoted_short_string.SingleQuotedShortString.__eq__."""
-    equality: bool = single_quoted_short_string == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_ellipsis_node.py
+++ b/tests/nodes/python/test_ellipsis_node.py
@@ -1,8 +1,4 @@
 """Test arborista.nodes.python.ellipsis_node."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.atom import Atom
 from arborista.nodes.python.ellipsis_node import EllipsisNode
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.ellipsis_node import EllipsisNode
 def test_inheritance() -> None:
     """Test arborista.nodes.python.ellipsis_node.EllipsisNode inheritance."""
     assert issubclass(EllipsisNode, Atom)
-
-
-# yapf: disable
-@pytest.mark.parametrize('ellipsis_node, other, expected_equality', [
-    (EllipsisNode(), 'foo', False),
-    (EllipsisNode(), EllipsisNode(), True),
-])
-# yapf: enable
-def test_eq(ellipsis_node: EllipsisNode, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.ellipsis_node.EllipsisNode.__eq__."""
-    equality: bool = ellipsis_node == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_equals.py
+++ b/tests/nodes/python/test_equals.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.equals."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.equals import Equals
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.equals import Equals
 def test_inheritance() -> None:
     """Test aborista.nodes.python.equals.Equals inheritance."""
     assert issubclass(Equals, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('equals, other, expected_equality', [
-    (Equals(), 'foo', False),
-    (Equals(), Equals(), True),
-])
-# yapf: enable
-def test_eq(equals: Equals, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.equals.Equals.__eq__."""
-    equality: bool = equals == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_expression_statement.py
+++ b/tests/nodes/python/test_expression_statement.py
@@ -33,17 +33,3 @@ def test_init(expression: Expression, parent: Optional[Node], pass_parent: bool)
 
     assert expression_statement.expression == expression
     assert expression_statement.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('expression_statement, other, expected_equality', [
-    (ExpressionStatement(Integer(5)), 'foo', False),
-    (ExpressionStatement(Integer(5)), ExpressionStatement(Integer(7)), False),
-    (ExpressionStatement(Integer(5)), ExpressionStatement(Integer(5)), True),
-])
-# yapf: enable
-def test_eq(expression_statement: ExpressionStatement, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.expression_statement.ExpressionStatement.__eq__."""
-    equality: bool = expression_statement == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_float.py
+++ b/tests/nodes/python/test_float.py
@@ -31,17 +31,3 @@ def test_init(value: int, parent: Optional[Node], pass_parent: bool) -> None:
 
     assert float_.value == value
     assert float_.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('float_, other, expected_equality', [
-    (Float(1.0), 'foo', False),
-    (Float(1.0), Float(2.0), False),
-    (Float(1.0), Float(1.0), True),
-])
-# yapf: enable
-def test_eq(float_: Float, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.float.Float.__eq__."""
-    equality: bool = float_ == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_function_definition.py
+++ b/tests/nodes/python/test_function_definition.py
@@ -55,22 +55,6 @@ def test_function_definition_init(name: Name, parameters: Parameters, body: Suit
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('function_definition, other, expected_equality', [
-    (FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), 'bar', False),
-    (FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), FunctionDefinition(Name('bar'), [], SimpleStatement([ReturnStatement()])), False),
-    (FunctionDefinition(Name('foo'), [Parameter(Name('x'))], SimpleStatement([ReturnStatement()])), FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), False),
-    (FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement(), ReturnStatement()])), False),
-    (FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(function_definition: FunctionDefinition, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.function_definition.__eq__."""
-    equality: bool = function_definition == other
-
-    assert equality == expected_equality
-
-
-# yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('function_definition, expected_children_list', [
     (FunctionDefinition(Name('foo'), [], SimpleStatement([ReturnStatement()])), [Name('foo'), SimpleStatement([ReturnStatement()])]),
     (FunctionDefinition(Name('foo'), [], Block([SimpleStatement([ReturnStatement()])], '    ')), [Name('foo'), Block([SimpleStatement([ReturnStatement()])], '    ')]),

--- a/tests/nodes/python/test_greater_than.py
+++ b/tests/nodes/python/test_greater_than.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.greater_than."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.greater_than import GreaterThan
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.greater_than import GreaterThan
 def test_inheritance() -> None:
     """Test aborista.nodes.python.greater_than.GreaterThan inheritance."""
     assert issubclass(GreaterThan, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('greater_than, other, expected_equality', [
-    (GreaterThan(), 'foo', False),
-    (GreaterThan(), GreaterThan(), True),
-])
-# yapf: enable
-def test_eq(greater_than: GreaterThan, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.greater_than.GreaterThan.__eq__."""
-    equality: bool = greater_than == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_greater_than_or_equals.py
+++ b/tests/nodes/python/test_greater_than_or_equals.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.greater_than_or_equals."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.greater_than_or_equals import GreaterThanOrEquals
 
@@ -10,17 +6,3 @@ from arborista.nodes.python.greater_than_or_equals import GreaterThanOrEquals
 def test_inheritance() -> None:
     """Test aborista.nodes.python.greater_than_or_equals.GreaterThanOrEquals inheritance."""
     assert issubclass(GreaterThanOrEquals, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('greater_than_or_equals, other, expected_equality', [
-    (GreaterThanOrEquals(), 'foo', False),
-    (GreaterThanOrEquals(), GreaterThanOrEquals(), True),
-])
-# yapf: enable
-def test_eq(greater_than_or_equals: GreaterThanOrEquals, other: Any,
-            expected_equality: bool) -> None:
-    """Test aborista.nodes.python.greater_than_or_equals.GreaterThanOrEquals.__eq__."""
-    equality: bool = greater_than_or_equals == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_grouped_name_as_names.py
+++ b/tests/nodes/python/test_grouped_name_as_names.py
@@ -35,17 +35,3 @@ def test_init(name_as_names: NameAsNames, parent: Optional[Node], pass_parent: b
 
     assert grouped_name_as_names.name_as_names == name_as_names
     assert grouped_name_as_names.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('grouped_name_as_names, other, expected_equality', [
-    (GroupedNameAsNames(NameAsNames(NameAsName(Name('foo')), [])), 'foo', False),
-    (GroupedNameAsNames(NameAsNames(NameAsName(Name('foo')), [])), GroupedNameAsNames(NameAsNames(NameAsName(Name('bar')), [])), False),
-    (GroupedNameAsNames(NameAsNames(NameAsName(Name('foo')), [])), GroupedNameAsNames(NameAsNames(NameAsName(Name('foo')), [])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(grouped_name_as_names: GroupedNameAsNames, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.grouped_name_as_names.GroupedNameAsNames.__eq__."""
-    equality: bool = grouped_name_as_names == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_imaginary.py
+++ b/tests/nodes/python/test_imaginary.py
@@ -35,17 +35,3 @@ def test_init(value: Union[int, float], parent: Optional[Node], pass_parent: boo
 
     assert imaginary.value == value
     assert imaginary.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('imaginary, other, expected_equality', [
-    (Imaginary(1), 'foo', False),
-    (Imaginary(1), Imaginary(2), False),
-    (Imaginary(1), Imaginary(1), True),
-])
-# yapf: enable
-def test_eq(imaginary: Imaginary, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.imaginary.Imaginary.__eq__."""
-    equality: bool = imaginary == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_import_dotted_name.py
+++ b/tests/nodes/python/test_import_dotted_name.py
@@ -37,17 +37,3 @@ def test_init(dotted_name_as_names: DottedNameAsNames, parent: Optional[Node],
 
     assert import_dotted_name.dotted_name_as_names == dotted_name_as_names
     assert import_dotted_name.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('import_dotted_name, other, expected_equality', [
-    (ImportDottedName(DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [])), 'foo', False),
-    (ImportDottedName(DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [])), ImportDottedName(DottedNameAsNames(DottedNameAsName(DottedName(Name('bar'), [])), [])), False),
-    (ImportDottedName(DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [])), ImportDottedName(DottedNameAsNames(DottedNameAsName(DottedName(Name('foo'), [])), [])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(import_dotted_name: ImportDottedName, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.import_dotted_name.ImportDottedName.__eq__."""
-    equality: bool = import_dotted_name == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_import_from.py
+++ b/tests/nodes/python/test_import_from.py
@@ -10,7 +10,6 @@ from arborista.nodes.python.grouped_name_as_names import GroupedNameAsNames
 from arborista.nodes.python.import_from import ImportFrom, Source, Target
 from arborista.nodes.python.import_statement import ImportStatement
 from arborista.nodes.python.name import Name
-from arborista.nodes.python.name_as_name import NameAsName
 from arborista.nodes.python.name_as_names import NameAsNames
 from arborista.nodes.python.relative_dotted_name import RelativeDottedName
 from arborista.nodes.python.star import Star
@@ -51,18 +50,3 @@ def test_init(source: Source, target: Target, parent: Optional[Node], pass_paren
     assert import_from.source == source
     assert import_from.target == target
     assert import_from.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('import_from, other, expected_equality', [
-    (ImportFrom(DottedName(Name('foo'), []), Star()), 'foo', False),
-    (ImportFrom(DottedName(Name('foo'), []), Star()), ImportFrom(DottedName(Name('foo'), []), NameAsNames(NameAsName(Name('foo')), [])), False),
-    (ImportFrom(DottedName(Name('foo'), []), Star()), ImportFrom(DottedName(Name('bar'), []), Star()), False),
-    (ImportFrom(DottedName(Name('foo'), []), Star()), ImportFrom(DottedName(Name('foo'), []), Star()), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(import_from: ImportFrom, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.import_from.ImportFrom.__eq__."""
-    equality: bool = import_from == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_in.py
+++ b/tests/nodes/python/test_in.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.in_."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.in_ import In
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.in_ import In
 def test_inheritance() -> None:
     """Test aborista.nodes.python.in_.In inheritance."""
     assert issubclass(In, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('in_, other, expected_equality', [
-    (In(), 'foo', False),
-    (In(), In(), True),
-])
-# yapf: enable
-def test_eq(in_: In, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.in_.In.__eq__."""
-    equality: bool = in_ == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_integer.py
+++ b/tests/nodes/python/test_integer.py
@@ -31,17 +31,3 @@ def test_init(value: int, parent: Optional[Node], pass_parent: bool) -> None:
 
     assert integer.value == value
     assert integer.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('integer, other, expected_equality', [
-    (Integer(1), 'foo', False),
-    (Integer(1), Integer(2), False),
-    (Integer(1), Integer(1), True),
-])
-# yapf: enable
-def test_eq(integer: Integer, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.integer.Integer.__eq__."""
-    equality: bool = integer == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_is.py
+++ b/tests/nodes/python/test_is.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.is_."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.is_ import Is
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.is_ import Is
 def test_inheritance() -> None:
     """Test aborista.nodes.python.is_.Is inheritance."""
     assert issubclass(Is, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('is_, other, expected_equality', [
-    (Is(), 'foo', False),
-    (Is(), Is(), True),
-])
-# yapf: enable
-def test_eq(is_: Is, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.is_.Is.__eq__."""
-    equality: bool = is_ == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_is_not.py
+++ b/tests/nodes/python/test_is_not.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.is_not."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.is_not import IsNot
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.is_not import IsNot
 def test_inheritance() -> None:
     """Test aborista.nodes.python.is_not.IsNot inheritance."""
     assert issubclass(IsNot, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('is_not, other, expected_equality', [
-    (IsNot(), 'foo', False),
-    (IsNot(), IsNot(), True),
-])
-# yapf: enable
-def test_eq(is_not: IsNot, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.is_not.IsNot.__eq__."""
-    equality: bool = is_not == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_joined_string.py
+++ b/tests/nodes/python/test_joined_string.py
@@ -50,22 +50,3 @@ def test_init(strings: Iterable[String], parent: Optional[Node], pass_parent: bo
 
     assert joined_string.strings == expected_strings
     assert joined_string.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('joined_string, other, expected_equality', [
-    (JoinedString([]), 'foo', False),
-    (JoinedString([]), JoinedString([String(None, SingleQuotedShortString('foo'))]), False),
-    (JoinedString([String(None, SingleQuotedShortString('foo'))]), JoinedString([]), False),
-    (JoinedString([String(None, SingleQuotedShortString(''))]), JoinedString([String(None, SingleQuotedShortString(''))]), True),
-    (JoinedString([String(None, SingleQuotedShortString('foo'))]), JoinedString([String(None, SingleQuotedShortString('bar'))]), False),
-    (JoinedString([String(None, SingleQuotedShortString('foo'))]), JoinedString([String(None, SingleQuotedShortString('foo'))]), True),
-    (JoinedString([String(None, SingleQuotedShortString(''))]), JoinedString([String(None, SingleQuotedShortString('')), String(None, SingleQuotedShortString(''))]), False),
-    (JoinedString([String(None, SingleQuotedShortString('')), String(None, SingleQuotedShortString(''))]), JoinedString([String(None, SingleQuotedShortString('')), String(None, SingleQuotedShortString(''))]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(joined_string: JoinedString, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.joined_string.__eq__."""
-    equality: bool = joined_string == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_less_greater_than.py
+++ b/tests/nodes/python/test_less_greater_than.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.less_greater_than."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.less_greater_than import LessGreaterThan
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.less_greater_than import LessGreaterThan
 def test_inheritance() -> None:
     """Test aborista.nodes.python.less_greater_than.LessGreaterThan inheritance."""
     assert issubclass(LessGreaterThan, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('less_greater_than, other, expected_equality', [
-    (LessGreaterThan(), 'foo', False),
-    (LessGreaterThan(), LessGreaterThan(), True),
-])
-# yapf: enable
-def test_eq(less_greater_than: LessGreaterThan, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.less_greater_than.LessGreaterThan.__eq__."""
-    equality: bool = less_greater_than == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_less_than.py
+++ b/tests/nodes/python/test_less_than.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.less_than."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.less_than import LessThan
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.less_than import LessThan
 def test_inheritance() -> None:
     """Test aborista.nodes.python.less_than.LessThan inheritance."""
     assert issubclass(LessThan, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('less_than, other, expected_equality', [
-    (LessThan(), 'foo', False),
-    (LessThan(), LessThan(), True),
-])
-# yapf: enable
-def test_eq(less_than: LessThan, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.less_than.LessThan.__eq__."""
-    equality: bool = less_than == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_less_than_or_equals.py
+++ b/tests/nodes/python/test_less_than_or_equals.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.less_than_or_equals."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.less_than_or_equals import LessThanOrEquals
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.less_than_or_equals import LessThanOrEquals
 def test_inheritance() -> None:
     """Test aborista.nodes.python.less_than_or_equals.LessThanOrEquals inheritance."""
     assert issubclass(LessThanOrEquals, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('less_than_or_equals, other, expected_equality', [
-    (LessThanOrEquals(), 'foo', False),
-    (LessThanOrEquals(), LessThanOrEquals(), True),
-])
-# yapf: enable
-def test_eq(less_than_or_equals: LessThanOrEquals, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.less_than_or_equals.LessThanOrEquals.__eq__."""
-    equality: bool = less_than_or_equals == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_module.py
+++ b/tests/nodes/python/test_module.py
@@ -51,21 +51,6 @@ def test_module_init(name: str, statements: Optional[Statements], pass_statement
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('module, other, expected_equality', [
-    (Module('foo'), 'bar', False),
-    (Module('foo'), Module('bar'), False),
-    (Module('foo', [FunctionDefinition(Name('bar'), [], SimpleStatement([ReturnStatement()]))]), Module('foo'), False),
-    (Module('foo'), Module('foo'), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(module: Module, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.module.__eq__."""
-    equality: bool = module == other
-
-    assert equality == expected_equality
-
-
-# yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('module, expected_children_list', [
     (Module('foo'), []),
     (Module('foo', [FunctionDefinition(Name('bar'), [], SimpleStatement([ReturnStatement()]))]), [FunctionDefinition(Name('bar'), [], SimpleStatement([ReturnStatement()]))]),

--- a/tests/nodes/python/test_name.py
+++ b/tests/nodes/python/test_name.py
@@ -33,19 +33,6 @@ def test_init(value: str, parent: Optional[Node], pass_parent: bool) -> None:
     assert name.parent is parent
 
 
-# yapf: disable
-@pytest.mark.parametrize('name, other, expected_equality', [
-    (Name('foo'), 'bar', False),
-    (Name('foo'), Name('foo'), True),
-])
-# yapf: enable
-def test_eq(name: Name, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.name.__eq__."""
-    equality: bool = name == other
-
-    assert equality == expected_equality
-
-
 def test_names() -> None:
     """Test arborista.nodes.python.name.Names."""
     assert issubclass(Names, Iterable)

--- a/tests/nodes/python/test_name_as_name.py
+++ b/tests/nodes/python/test_name_as_name.py
@@ -38,17 +38,3 @@ def test_init(name: Name, new_name: Optional[Name], parent: Optional[Node], pass
     assert name_as_name.name == name
     assert name_as_name.new_name == new_name
     assert name_as_name.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('name_as_name, other, expected_equality', [
-    (NameAsName(Name('foo')), 'foo', False),
-    (NameAsName(Name('foo')), NameAsName(Name('foo'), Name('bar')), False),
-    (NameAsName(Name('foo'), Name('bar')), NameAsName(Name('foo'), Name('bar')), True),
-])
-# yapf: enable
-def test_eq(name_as_name: NameAsName, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.name_as_name.NameAsName.__eq__."""
-    equality: bool = name_as_name == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_name_as_names.py
+++ b/tests/nodes/python/test_name_as_names.py
@@ -35,17 +35,3 @@ def test_init(first: NameAsName, rest: List[NameAsName], parent: Optional[Node],
     assert name_as_names.first == first
     assert name_as_names.rest == rest
     assert name_as_names.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('name_as_names, other, expected_equality', [
-    (NameAsNames(NameAsName(Name('foo')), []), 'foo', False),
-    (NameAsNames(NameAsName(Name('foo')), []), NameAsNames(NameAsName(Name('foo')), [NameAsName(Name('bar'))]), False),
-    (NameAsNames(NameAsName(Name('foo')), [NameAsName(Name('bar'))]), NameAsNames(NameAsName(Name('foo')), [NameAsName(Name('bar'))]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(name_as_names: NameAsNames, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.name_as_names.NameAsNames.__eq__."""
-    equality: bool = name_as_names == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_not_equals.py
+++ b/tests/nodes/python/test_not_equals.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.not_equals."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.not_equals import NotEquals
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.not_equals import NotEquals
 def test_inheritance() -> None:
     """Test aborista.nodes.python.not_equals.NotEquals inheritance."""
     assert issubclass(NotEquals, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('not_equals, other, expected_equality', [
-    (NotEquals(), 'foo', False),
-    (NotEquals(), NotEquals(), True),
-])
-# yapf: enable
-def test_eq(not_equals: NotEquals, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.not_equals.NotEquals.__eq__."""
-    equality: bool = not_equals == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_not_in.py
+++ b/tests/nodes/python/test_not_in.py
@@ -1,8 +1,4 @@
 """Test aborista.nodes.python.not_in."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.comparison_operator import ComparisonOperator
 from arborista.nodes.python.not_in import NotIn
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.not_in import NotIn
 def test_inheritance() -> None:
     """Test aborista.nodes.python.not_in.NotIn inheritance."""
     assert issubclass(NotIn, ComparisonOperator)
-
-
-# yapf: disable
-@pytest.mark.parametrize('not_in, other, expected_equality', [
-    (NotIn(), 'foo', False),
-    (NotIn(), NotIn(), True),
-])
-# yapf: enable
-def test_eq(not_in: NotIn, other: Any, expected_equality: bool) -> None:
-    """Test aborista.nodes.python.not_in.NotIn.__eq__."""
-    equality: bool = not_in == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_or.py
+++ b/tests/nodes/python/test_or.py
@@ -1,5 +1,5 @@
 """Test arborista.nodes.python.or_."""
-from typing import Any, Optional
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,16 +28,3 @@ def test_init(parent: Optional[Expression], pass_parent: bool) -> None:
     or_: Or = Or(**keyword_arguments)
 
     assert or_.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('or_, other, expected_equality', [
-    (Or(), 'foo', False),
-    (Or(), Or(), True),
-])
-# yapf: enable
-def test_eq(or_: Or, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.or_.Or.__eq__."""
-    equality: bool = or_ == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_parameter.py
+++ b/tests/nodes/python/test_parameter.py
@@ -36,19 +36,6 @@ def test_init(name: Name, parent: Optional[Node], pass_parent: bool) -> None:
 
 
 # yapf: disable
-@pytest.mark.parametrize('parameter, other, expected_equality', [
-    (Parameter(Name('foo')), 'bar', False),
-    (Parameter(Name('foo')), Parameter(Name('foo')), True),
-])
-# yapf: enable
-def test_eq(parameter: Parameter, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.parameter.Parameter.__eq__."""
-    equality: bool = parameter == other
-
-    assert equality == expected_equality
-
-
-# yapf: disable
 @pytest.mark.parametrize('parameter, expected_children_list', [
     (Parameter(Name('foo')), [Name('foo')]),
 ])

--- a/tests/nodes/python/test_pass_statement.py
+++ b/tests/nodes/python/test_pass_statement.py
@@ -1,8 +1,4 @@
 """Test arborista.nodes.python.pass_statement."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.pass_statement import PassStatement
 from arborista.nodes.python.small_statement import SmallStatement
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.small_statement import SmallStatement
 def test_inheritance() -> None:
     """Test arborista.nodes.python.pass_statement.PassStatement inheritance."""
     assert issubclass(PassStatement, SmallStatement)
-
-
-# yapf: disable
-@pytest.mark.parametrize('pass_statement, other, expected_equality', [
-    (PassStatement(), 'foo', False),
-    (PassStatement(), PassStatement(), True),
-])
-# yapf: enable
-def test_eq(pass_statement: PassStatement, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.pass_statement.PassStatement.__eq__."""
-    equality: bool = pass_statement == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_python_node.py
+++ b/tests/nodes/python/test_python_node.py
@@ -1,4 +1,10 @@
 """Test arborista.nodes.python.python_node."""
+from abc import ABC
+from typing import Any, Dict
+
+import pytest
+from seligimus.python.classes.attributes import set_attributes
+
 from arborista.node import Node
 from arborista.nodes.python.python_node import PythonNode
 
@@ -6,3 +12,32 @@ from arborista.nodes.python.python_node import PythonNode
 def test_inheritance() -> None:
     """Test arborista.nodes.python.python_node.PythonNode inheritance."""
     assert issubclass(PythonNode, Node)
+    assert ABC in PythonNode.__bases__
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('self_class_name, other_class_name, self_attributes, other_attributes, expected_equality', [
+    ('Foo', 'Bar', {'parent': 1}, {'parent': 1}, False),
+    ('Foo', 'Foo', {'parent': 1, 'wibble': 2}, {'parent': 1, 'wibble': 3}, False),
+    ('Foo', 'Foo', {'parent': 1}, {'parent': 2}, True),
+    ('Foo', 'Foo', {'parent': 1, 'wibble': 2}, {'parent': 1, 'wibble': 2}, True),
+    ('Foo', 'Foo', {'parent': 1, 'wibble': 2}, {'parent': 2, 'wibble': 2}, True),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_eq(self_class_name: str, other_class_name: str, self_attributes: Dict[str, Any],
+            other_attributes: Dict[str, Any], expected_equality: bool) -> None:
+    """Test arborista.nodes.python.python_node.PythonNode.__eq__."""
+    self_type = type(self_class_name, tuple(), {})
+    self = self_type()
+    set_attributes(self, self_attributes)
+
+    if other_class_name == self_class_name:
+        other_type = self_type
+    else:
+        other_type = type(other_class_name, tuple(), {})
+    other = other_type()
+    set_attributes(other, other_attributes)
+
+    equality: bool = PythonNode.__eq__(self, other)
+
+    assert equality == expected_equality

--- a/tests/nodes/python/test_relative_dotted_name.py
+++ b/tests/nodes/python/test_relative_dotted_name.py
@@ -37,18 +37,3 @@ def test_init(dots: int, dotted_name: Optional[DottedName], parent: Optional[Nod
     assert relative_dotted_name.dots == dots
     assert relative_dotted_name.dotted_name == dotted_name
     assert relative_dotted_name.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('relative_dotted_name, other, expected_equality', [
-    (RelativeDottedName(0, DottedName(Name('foo'), [])), 'foo', False),
-    (RelativeDottedName(0, DottedName(Name('foo'), [])), RelativeDottedName(0, DottedName(Name('bar'), [])), False),
-    (RelativeDottedName(1, DottedName(Name('foo'), [])), RelativeDottedName(0, DottedName(Name('foo'), [])), False),
-    (RelativeDottedName(0, DottedName(Name('foo'), [])), RelativeDottedName(0, DottedName(Name('foo'), [])), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(relative_dotted_name: RelativeDottedName, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.relative_dotted_name.RelativeDottedName.__eq__."""
-    equality: bool = relative_dotted_name == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_return_statement.py
+++ b/tests/nodes/python/test_return_statement.py
@@ -1,8 +1,4 @@
 """Test arborista.nodes.python.return_statement."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.flow_statement import FlowStatement
 from arborista.nodes.python.return_statement import ReturnStatement
 
@@ -10,16 +6,3 @@ from arborista.nodes.python.return_statement import ReturnStatement
 def test_inheritance() -> None:
     """Test arborista.nodes.python.return_statement.ReturnStatement inheritance."""
     assert issubclass(ReturnStatement, FlowStatement)
-
-
-# yapf: disable
-@pytest.mark.parametrize('return_statement, other, expected_equality', [
-    (ReturnStatement(), 'foo', False),
-    (ReturnStatement(), ReturnStatement(), True),
-])
-# yapf: enable
-def test_eq(return_statement: ReturnStatement, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.return_statement.ReturnStatement.__eq__."""
-    equality: bool = return_statement == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_simple_statement.py
+++ b/tests/nodes/python/test_simple_statement.py
@@ -37,19 +37,6 @@ def test_simple_statement_init(small_statements: SmallStatements, parent: Option
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('simple_statement, other, expected_equality', [
-    (SimpleStatement(small_statements=[ReturnStatement()]), 'foo', False),
-    (SimpleStatement(small_statements=[ReturnStatement()]), SimpleStatement(small_statements=[ReturnStatement()]), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(simple_statement: SimpleStatement, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.simple_statement.__eq__."""
-    equality: bool = simple_statement == other
-
-    assert equality == expected_equality
-
-
-# yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('simple_statement, expected_children_list', [
     (SimpleStatement(small_statements=[]), []),
     (SimpleStatement(small_statements=[ReturnStatement()]), [ReturnStatement()]),

--- a/tests/nodes/python/test_single_quoted_long_string.py
+++ b/tests/nodes/python/test_single_quoted_long_string.py
@@ -32,18 +32,3 @@ def test_init(value: str, parent: Optional[Node], pass_parent: bool) -> None:
 
     assert single_quoted_long_string.value == value
     assert single_quoted_long_string.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('single_quoted_long_string, other, expected_equality', [
-    (SingleQuotedLongString('foo'), 'foo', False),
-    (SingleQuotedLongString('foo'), SingleQuotedLongString('bar'), False),
-    (SingleQuotedLongString('foo'), SingleQuotedLongString('foo'), True),
-])
-# yapf: enable
-def test_eq(single_quoted_long_string: SingleQuotedLongString, other: Any,
-            expected_equality: bool) -> None:
-    """Test arborista.nodes.python.single_quoted_long_string.SingleQuotedLongString.__eq__."""
-    equality: bool = single_quoted_long_string == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_single_quoted_short_string.py
+++ b/tests/nodes/python/test_single_quoted_short_string.py
@@ -32,18 +32,3 @@ def test_init(value: str, parent: Optional[Node], pass_parent: bool) -> None:
 
     assert single_quoted_short_string.value == value
     assert single_quoted_short_string.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('single_quoted_short_string, other, expected_equality', [
-    (SingleQuotedShortString('foo'), 'foo', False),
-    (SingleQuotedShortString('foo'), SingleQuotedShortString('bar'), False),
-    (SingleQuotedShortString('foo'), SingleQuotedShortString('foo'), True),
-])
-# yapf: enable
-def test_eq(single_quoted_short_string: SingleQuotedShortString, other: Any,
-            expected_equality: bool) -> None:
-    """Test arborista.nodes.python.single_quoted_short_string.SingleQuotedShortString.__eq__."""
-    equality: bool = single_quoted_short_string == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_star.py
+++ b/tests/nodes/python/test_star.py
@@ -1,25 +1,8 @@
 """Test arborista.nodes.python.star."""
-from typing import Any
-
-import pytest
-
 from arborista.nodes.python.python_node import PythonNode
 from arborista.nodes.python.star import Star
 
 
 def test_inheritance() -> None:
-    """Test arborista.nodes.python.python_node.PythonNode inheritance."""
+    """Test arborista.nodes.python.star.Star inheritance."""
     assert issubclass(Star, PythonNode)
-
-
-# yapf: disable
-@pytest.mark.parametrize('star, other, expected_equality', [
-    (Star(), 'foo', False),
-    (Star(), Star(), True),
-])
-# yapf: enable
-def test_eq(star: Star, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.star.Star.__eq__."""
-    equality: bool = star == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_string.py
+++ b/tests/nodes/python/test_string.py
@@ -42,17 +42,3 @@ def test_init(prefix: Optional[StringPrefix], value: StringValue, parent: Option
     assert string.prefix == prefix
     assert string.value == value
     assert string.parent is parent
-
-
-# yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('string, other, expected_equality', [
-    (String(None, SingleQuotedShortString('foo')), 'foo', False),
-    (String(None, SingleQuotedShortString('foo')), String(StringPrefix('f'), SingleQuotedShortString('foo')), False),
-    (String(StringPrefix('f'), SingleQuotedShortString('foo')), String(StringPrefix('f'), SingleQuotedShortString('foo')), True),
-])
-# yapf: enable # pylint: enable=line-too-long
-def test_eq(string: String, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.string.String.__eq__."""
-    equality: bool = string == other
-
-    assert equality == expected_equality

--- a/tests/nodes/python/test_string_prefix.py
+++ b/tests/nodes/python/test_string_prefix.py
@@ -39,17 +39,3 @@ def test_init(value: StringPrefixValue, parent: Optional[Node], pass_parent: boo
 
     assert string_prefix.value == value
     assert string_prefix.parent is parent
-
-
-# yapf: disable
-@pytest.mark.parametrize('string_prefix, other, expected_equality', [
-    (StringPrefix('f'), 'foo', False),
-    (StringPrefix('f'), StringPrefix('r'), False),
-    (StringPrefix('f'), StringPrefix('f'), True),
-])
-# yapf: enable
-def test_eq(string_prefix: StringPrefix, other: Any, expected_equality: bool) -> None:
-    """Test arborista.nodes.python.string_prefix.StringPrefix.__eq__."""
-    equality: bool = string_prefix == other
-
-    assert equality == expected_equality

--- a/tests/parsers/python/test_block_parser.py
+++ b/tests/parsers/python/test_block_parser.py
@@ -17,8 +17,8 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('libcst_block, expected_block', [
-    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])]), Block([SimpleStatement(small_statements=[ReturnStatement()])], '   ')),
-    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])], indent='    '), Block([SimpleStatement(small_statements=[ReturnStatement()])], '   ')),
+    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])]), Block([SimpleStatement(small_statements=[ReturnStatement()])], '    ')),
+    (libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])], indent='    '), Block([SimpleStatement(small_statements=[ReturnStatement()])], '    ')),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_block(libcst_block: LibcstBlock, expected_block: Block) -> None:

--- a/tests/parsers/python/test_function_definition_parser.py
+++ b/tests/parsers/python/test_function_definition_parser.py
@@ -21,8 +21,8 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('libcst_function_definition, expected_function_definition', [
-    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters(), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[], body=Block([SimpleStatement([ReturnStatement()])], '   '))),
-    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters([libcst.Param(libcst.Name('bar'))]), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[Parameter(Name('bar'))], body=Block([SimpleStatement([ReturnStatement()])], '   '))),
+    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters(), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[], body=Block([SimpleStatement([ReturnStatement()])], '    '))),
+    (libcst.FunctionDef(name=libcst.Name(value='foo'), params=libcst.Parameters([libcst.Param(libcst.Name('bar'))]), body=libcst.IndentedBlock([libcst.SimpleStatementLine([libcst.Return()])])), FunctionDefinition(name=Name('foo'), parameters=[Parameter(Name('bar'))], body=Block([SimpleStatement([ReturnStatement()])], '    '))),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_parse_function_definition(libcst_function_definition: LibcstFunctionDefinition,


### PR DESCRIPTION
Bump Seligimus to version 0.13.0 and refactor some equality operators for nodes. There is some more equality operator refactoring that could be done (pull definition into `Node`, refactor whitespace nodes, refactor file system nodes), but this is probably good for now. The main reason for doing this is to reduce the amount of time it takes to implement Python nodes.